### PR TITLE
Add repetition detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-2,466 bytes
+2,582 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -323,6 +323,8 @@ def rename(tokens):
         "func":"bv",
         "best_move_index":"cb",
         "killer":"cd",
+        "history":"ce",
+        "old_pos":"cf",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -390,7 +390,7 @@ int alphabeta(Position &pos,
 
     else if (ply > 0) {
         // Repetition detection
-        for (auto &old_pos : history) {
+        for (const auto &old_pos : history) {
             if (old_pos.pieces == pos.pieces && old_pos.colour == pos.colour && old_pos.flipped == pos.flipped) {
                 return 0;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -386,9 +386,7 @@ int alphabeta(Position &pos,
         if (alpha < static_eval) {
             alpha = static_eval;
         }
-    }
-
-    else if (ply > 0) {
+    } else if (ply > 0) {
         // Repetition detection
         for (const auto &old_pos : history) {
             if (old_pos.pieces == pos.pieces && old_pos.colour == pos.colour && old_pos.flipped == pos.flipped) {
@@ -403,7 +401,6 @@ int alphabeta(Position &pos,
                 return beta;
             }
         }
-
         // Null move pruning
         else if (!in_check && static_eval >= beta && beta - alpha > 1) {
             auto npos = pos;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,9 @@
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <ctime>
 #include <iostream>
 #include <string>
-#include <array>
 #include <vector>
 
 #define MATE_SCORE (1 << 15)
@@ -39,11 +39,11 @@ using BB = uint64_t;
 struct [[nodiscard]] Position {
     array<BB, 2> colour = {0xFFFFULL, 0xFFFF000000000000ULL};
     array<BB, 6> pieces = {0xFF00000000FF00ULL,
-                    0x4200000000000042ULL,
-                    0x2400000000000024ULL,
-                    0x8100000000000081ULL,
-                    0x800000000000008ULL,
-                    0x1000000000000010ULL};
+                           0x4200000000000042ULL,
+                           0x2400000000000024ULL,
+                           0x8100000000000081ULL,
+                           0x800000000000008ULL,
+                           0x1000000000000010ULL};
     BB ep = 0x0ULL;
     array<int, 4> castling = {true, true, true, true};
     int flipped = false;
@@ -370,7 +370,7 @@ int alphabeta(Position &pos,
               const int ply,
               const long long int stop_time,
               Stack *const stack,
-              vector<Position>& history) {
+              vector<Position> &history) {
     const int ksq = lsb(pos.colour[0] & pos.pieces[King]);
     const auto in_check = attacked(pos, ksq);
     const int static_eval = eval(pos);
@@ -390,7 +390,7 @@ int alphabeta(Position &pos,
 
     else if (ply > 0) {
         // Repetition detection
-        for (auto& old_pos : history) {
+        for (auto &old_pos : history) {
             if (old_pos.pieces == pos.pieces && old_pos.colour == pos.colour && old_pos.flipped == pos.flipped) {
                 return 0;
             }
@@ -531,13 +531,12 @@ int main() {
             const int num_moves = movegen(pos, moves);
             for (int i = 0; i < num_moves; ++i) {
                 if (word == move_str(moves[i], pos.flipped)) {
-                    if(piece_on(pos, moves[i].to) != None || piece_on(pos, moves[i].from) == Pawn) {
+                    if (piece_on(pos, moves[i].to) != None || piece_on(pos, moves[i].from) == Pawn) {
                         history.clear();
-                    }
-                    else {
+                    } else {
                         history.push_back(pos);
                     }
-                    
+
                     makemove(pos, moves[i]);
                     break;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -403,15 +403,16 @@ int alphabeta(Position &pos,
                 return beta;
             }
         }
-    }
-    // Null move pruning
-    else if (!in_check && static_eval >= beta && beta - alpha > 1) {
-    	auto npos = pos;
-    	flip(npos);
-    	npos.ep = 0;
-    	if (-alphabeta(npos, -beta, -beta + 1, depth - 3, ply + 1, stop_time, stack) >= beta) {
-    		return beta;
-    	}
+
+        // Null move pruning
+        else if (!in_check && static_eval >= beta && beta - alpha > 1) {
+            auto npos = pos;
+            flip(npos);
+            npos.ep = 0;
+            if (-alphabeta(npos, -beta, -beta + 1, depth - 3, ply + 1, stop_time, stack, history) >= beta) {
+                return beta;
+            }
+        }
     }
 
     // Exit early if out of time

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,8 @@
 #include <ctime>
 #include <iostream>
 #include <string>
+#include <array>
+#include <vector>
 
 #define MATE_SCORE (1 << 15)
 #define INF (1 << 16)
@@ -35,15 +37,15 @@ struct [[nodiscard]] Move {
 using BB = uint64_t;
 
 struct [[nodiscard]] Position {
-    BB colour[2] = {0xFFFFULL, 0xFFFF000000000000ULL};
-    BB pieces[6] = {0xFF00000000FF00ULL,
+    array<BB, 2> colour = {0xFFFFULL, 0xFFFF000000000000ULL};
+    array<BB, 6> pieces = {0xFF00000000FF00ULL,
                     0x4200000000000042ULL,
                     0x2400000000000024ULL,
                     0x8100000000000081ULL,
                     0x800000000000008ULL,
                     0x1000000000000010ULL};
     BB ep = 0x0ULL;
-    bool castling[4] = {true, true, true, true};
+    array<bool, 4> castling = {true, true, true, true};
     bool flipped = false;
 };
 
@@ -367,7 +369,8 @@ int alphabeta(Position &pos,
               int depth,
               const int ply,
               const long long int stop_time,
-              Stack *const stack) {
+              Stack *const stack,
+              vector<Position>& history) {
     const int ksq = lsb(pos.colour[0] & pos.pieces[King]);
     const auto in_check = attacked(pos, ksq);
     const int static_eval = eval(pos);
@@ -384,11 +387,21 @@ int alphabeta(Position &pos,
             alpha = static_eval;
         }
     }
-    // Reverse futility pruning
-    else if (depth < 3) {
-        const int margin = 120;
-        if (static_eval - margin * depth >= beta) {
-            return beta;
+
+    else if (ply > 0) {
+        // Repetition detection
+        for (auto& old_pos : history) {
+            if (old_pos.pieces == pos.pieces && old_pos.colour == pos.colour && old_pos.flipped == pos.flipped) {
+                return 0;
+            }
+        }
+
+        // Reverse futility pruning
+        if (depth < 3) {
+            const int margin = 120;
+            if (static_eval - margin * depth >= beta) {
+                return beta;
+            }
         }
     }
 
@@ -418,6 +431,7 @@ int alphabeta(Position &pos,
     }
 
     int best_score = -INF;
+    history.push_back(pos);
     for (int i = 0; i < num_moves; ++i) {
         // Find best move remaining
         int best_move_index = i;
@@ -440,7 +454,7 @@ int alphabeta(Position &pos,
             continue;
         }
 
-        const int score = -alphabeta(npos, -beta, -alpha, depth - 1, ply + 1, stop_time, stack);
+        const int score = -alphabeta(npos, -beta, -alpha, depth - 1, ply + 1, stop_time, stack, history);
 
         if (score > best_score) {
             best_score = score;
@@ -458,6 +472,7 @@ int alphabeta(Position &pos,
             break;
         }
     }
+    history.pop_back();
 
     // Return mate or draw scores if no moves found and not in qsearch
     if (!in_qsearch && best_score == -INF) {
@@ -470,6 +485,7 @@ int alphabeta(Position &pos,
 int main() {
     setbuf(stdout, NULL);
     Position pos;
+    vector<Position> history;
     Move moves[256];
     getchar();
     puts("id name 4ku2\nid author kz04px\nuciok");
@@ -491,7 +507,7 @@ int main() {
             string bestmove_str;
             Stack stack[128];
             for (int i = 1; i < 128; ++i) {
-                alphabeta(pos, -INF, INF, i, 0, stop_time, stack);
+                alphabeta(pos, -INF, INF, i, 0, stop_time, stack, history);
                 if (now() >= stop_time) {
                     break;
                 }
@@ -500,10 +516,18 @@ int main() {
             cout << "bestmove " << bestmove_str << "\n";
         } else if (word == "position") {
             pos = Position();
+            history.clear();
         } else {
             const int num_moves = movegen(pos, moves);
             for (int i = 0; i < num_moves; ++i) {
                 if (word == move_str(moves[i], pos.flipped)) {
+                    if(piece_on(pos, moves[i].to) != None || piece_on(pos, moves[i].from) == Pawn) {
+                        history.clear();
+                    }
+                    else {
+                        history.push_back(pos);
+                    }
+                    
                     makemove(pos, moves[i]);
                     break;
                 }


### PR DESCRIPTION
Old test without null move pruning
```
Score of 4ku2 vs 4ku2-master: 518 - 321 - 661  [0.566] 1500
...      4ku2 playing White: 299 - 154 - 297  [0.597] 750
...      4ku2 playing Black: 219 - 167 - 364  [0.535] 750
...      White vs Black: 466 - 373 - 661  [0.531] 1500
Elo difference: 45.9 +/- 13.2, LOS: 100.0 %, DrawRatio: 44.1 %
```

New test with null move pruning
```
Score of 4ku2 vs 4ku2-master: 339 - 224 - 437  [0.557] 1000
...      4ku2 playing White: 215 - 97 - 188  [0.618] 500
...      4ku2 playing Black: 124 - 127 - 249  [0.497] 500
...      White vs Black: 342 - 221 - 437  [0.560] 1000
Elo difference: 40.1 +/- 16.2, LOS: 100.0 %, DrawRatio: 43.7 %
```

Book: UHO_XXL_+0.90_+1.19.pgn
TC: 5+0.05

```
-rwxrwx--- 1 root vboxsf  3956 Nov 22 16:10 4ku2-compressed*
-rwxrwx--- 1 root vboxsf  2608 Nov 22 16:10 4ku2-compressed-mini*
-rwxrwx--- 1 root vboxsf 17103 Nov 22 16:10 4ku2-normal*
-rwxrwx--- 1 root vboxsf  6298 Nov 22 16:10 4ku2-normal-mini*
-rwxrwx--- 1 root vboxsf 32776 Nov 22 16:10 4ku-executable*
-rwxrwx--- 1 root vboxsf 32680 Nov 22 16:10 4ku-executable-mini*
```

2608-2498 = 110 bytes

Could probably be reduced significantly if we switch to C++20