### PR TITLE
Add tapered eval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+all:
+	g++ src/main.cpp -O3 -o ../out/4ku2.exe
+	strip -s ../out/4ku2.exe
+#g++ src/main.cpp -O3 -o ../out/4ku2.exe
+#g++ -std=c++20 src/main.cpp -O3 -o ../out/4ku2.exe

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-all:
-	g++ src/main.cpp -O3 -o ../out/4ku2.exe
-	strip -s ../out/4ku2.exe
-#g++ src/main.cpp -O3 -o ../out/4ku2.exe
-#g++ -std=c++20 src/main.cpp -O3 -o ../out/4ku2.exe

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-2,735 bytes
+2,733 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-2,740 bytes
+2,735 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-2,746 bytes
+2,737 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-2,737 bytes
+2,740 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-2,608 bytes
+2,746 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -325,6 +325,8 @@ def rename(tokens):
         "killer":"cd",
         "history":"ce",
         "old_pos":"cf",
+        "phase":"cg",
+        "phases":"ch",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -8,7 +8,7 @@ def get_args():
     return parser.parse_args()
 
 def get_keywords(src):
-    keywords = set({"int", "char", "auto", "bool", "void", "using", "namespace", "define", "else",
+    keywords = set({"int", "short", "char", "auto", "bool", "void", "using", "namespace", "define", "else",
 "long", "unsigned", "timespec", "struct", "class", "return", "operator", "typename", "const", "string", "goto",
 "uint64_t", "int64_t", "uint32_t", "int32_t", "uint16_t", "int16_t", "uint8_t", "int8_t"})
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -370,8 +370,8 @@ const int rook_rank78 = S(46, 11);
         score = -score;
     }
 
-    const int mg = (short)score;
-    const int eg = (short)((score + 0x8000) >> 16);
+    const short mg = score;
+    const int eg = score >> 16;
     return (mg * phase + eg * (24 - phase)) / 24;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -301,7 +301,7 @@ void generate_piece_moves(Move *const movelist,
 
 const int phases[] = {0, 1, 1, 2, 4, 0};
 
-int S(const int mg, const int eg) {
+[[nodiscard]] int S(const int mg, const int eg) {
     return (eg << 16) + mg;
 }
 
@@ -370,9 +370,8 @@ const int rook_rank78 = S(46, 11);
         score = -score;
     }
 
-    const short mg = score;
-    const int eg = (score + 0x8000) >> 16;
-    return (mg * phase + eg * (24 - phase)) / 24;
+    // Tapered eval
+    return ((short)score * phase + ((score + 0x8000) >> 16) * (24 - phase)) / 24;
 }
 
 int alphabeta(Position &pos,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,7 +371,7 @@ const int rook_rank78 = S(46, 11);
     }
 
     const short mg = score;
-    const int eg = score >> 16;
+    const int eg = (score + 0x8000) >> 16;
     return (mg * phase + eg * (24 - phase)) / 24;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -299,12 +299,11 @@ void generate_piece_moves(Move *const movelist,
     return num_moves;
 }
 
-const int phases[] = {0, 1, 1, 2, 4, 0};
-
 [[nodiscard]] int S(const int mg, const int eg) {
     return (eg << 16) + mg;
 }
 
+const int phases[] = { 0, 1, 1, 2, 4, 0 };
 const int material[] = {S(75, 111), S(387, 286), S(419, 326), S(505, 589), S(1182, 1070), 0};
 const int centralities[] = {S(14, -8), S(19, 21), S(20, 10), S(-4, 4), S(-5, 28), S(-47, 28)};
 const int passers[] = {S(29, 7), S(18, 7), S(-4, 19), S(7, 39), S(27, 112), S(106, 205)};


### PR DESCRIPTION
Test without negative value shift fix
```
Score of 4ku2 vs 4ku2-master: 745 - 513 - 242  [0.577] 1500
...      4ku2 playing White: 424 - 196 - 130  [0.652] 750
...      4ku2 playing Black: 321 - 317 - 112  [0.503] 750
...      White vs Black: 741 - 517 - 242  [0.575] 1500
Elo difference: 54.2 +/- 16.2, LOS: 100.0 %, DrawRatio: 16.1 %
```

Test after negative value shift fix
```
Score of 4ku2 vs 4ku2-master: 483 - 337 - 180  [0.573] 1000
...      4ku2 playing White: 280 - 135 - 86  [0.645] 501
...      4ku2 playing Black: 203 - 202 - 94  [0.501] 499
...      White vs Black: 482 - 338 - 180  [0.572] 1000
Elo difference: 51.1 +/- 19.7, LOS: 100.0 %, DrawRatio: 18.0 %
```

Book: UHO_XXL_+0.90_+1.19.pgn
TC: 5+0.05

```
-rwxrwx--- 1 root vboxsf  4108 Nov 22 21:59 4ku2-compressed*
-rwxrwx--- 1 root vboxsf  2733 Nov 22 21:59 4ku2-compressed-mini*
-rwxrwx--- 1 root vboxsf 17531 Nov 22 21:59 4ku2-normal*
-rwxrwx--- 1 root vboxsf  6554 Nov 22 21:59 4ku2-normal-mini*
-rwxrwx--- 1 root vboxsf 32968 Nov 22 21:59 4ku-executable*
-rwxrwx--- 1 root vboxsf 32656 Nov 22 21:59 4ku-executable-mini*
```

2733 - 2608 = 125 bytes