### PR TITLE
Fix TT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-3,132 bytes
+3,137 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -339,6 +339,7 @@ def rename(tokens):
         "tt_flag":"cr",
         "TT_Entry":"cs",
         "MAX_TT_SIZE":"ct",
+        "best_move":"cu",
         # Labels
         "do_search":"bk",
         "full_search":"bl",


### PR DESCRIPTION
1. `stack[ply].move` shouldn't be used anymore in move ordering, should put TT move first. But doing this alone lose 100 elo

2. There's a bug with storing best move, it's storing `stack[ply].move` as the TT move, but it only gets set if score beats alpha. Should have a separate variable like best_move and update it whenever a move beats best_score and store that in the TT. Fixng this makes it lose "only" 40 elo, and also draw ratio shoots up from ~27% to ~45%, and I started to see a lot of draws by 50 move rule for some reason.

3. I haven't fully worked out the interaction of what's happening here, but on mate detection returning `ply - MATE_SCORE` seems to fix whatever was happening with the weird interaction before, master is no longer able to abuse the draws (in whatever way it was doing it), draw ratio returned to normal. Haven't tested what size this ends up as yet. Also fixing all that gains 27 +- 13 on super short TC. No, only change being returning `ply - MATE_SCORE` doesn't gain anything, tested this. 

4. Will also test properly storing mate-ish scores in the TT, because there's some special care you need to do for them, but it might be too big. _(It was and didn't gain and yes it was big)_

5+0.05, 8moves_v3.pgn:
```
Score of 4ku2 vs 4ku2-master: 632 - 439 - 429  [0.564] 1500
...      4ku2 playing White: 312 - 217 - 221  [0.563] 750
...      4ku2 playing Black: 320 - 222 - 208  [0.565] 750
...      White vs Black: 534 - 537 - 429  [0.499] 1500
Elo difference: 45.0 +/- 14.9, LOS: 100.0 %, DrawRatio: 28.6 %
```

5+0.05, UHO_XXL_+0.90_+1.19.pgn:
```
Score of 4ku2 vs 4ku2-master: 223 - 161 - 116  [0.562] 500
...      4ku2 playing White: 129 - 62 - 60  [0.633] 251
...      4ku2 playing Black: 94 - 99 - 56  [0.490] 249
...      White vs Black: 228 - 156 - 116  [0.572] 500
Elo difference: 43.3 +/- 26.8, LOS: 99.9 %, DrawRatio: 23.2 %
```

```
-rwxrwx--- 1 root vboxsf  4780 Nov 25 03:49 4ku2-compressed*
-rwxrwx--- 1 root vboxsf  3137 Nov 25 03:49 4ku2-compressed-mini*
-rwxrwx--- 1 root vboxsf 20351 Nov 25 03:49 4ku2-normal*
-rwxrwx--- 1 root vboxsf  7497 Nov 25 03:49 4ku2-normal-mini*
-rwxrwx--- 1 root vboxsf 37464 Nov 25 03:49 4ku-executable*
-rwxrwx--- 1 root vboxsf 37136 Nov 25 03:49 4ku-executable-mini*
```

3137 - 3132 = 5 bytes