### PR TITLE
Add razoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-3,312 bytes
+3,339 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-3,339 bytes
+3,340 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -500,7 +500,7 @@ int alphabeta(Position &pos,
         }
 
         // Razoring
-        if (depth < 3 && !in_check && static_eval + depth * 300 < alpha) {
+        if (depth == 1 && !in_check && static_eval + 300 < alpha) {
             return alphabeta(pos, alpha, beta, 0, ply, stop_time, stack, hash_history, do_null);
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -506,7 +506,7 @@ int alphabeta(Position &pos,
 
         // Razoring
         if (depth == 1 && !in_check && static_eval + 300 < alpha) {
-            return alphabeta(pos, alpha, beta, 0, ply, stop_time, stack, hash_history, do_null);
+            return alphabeta(pos, alpha, beta, 0, ply, stop_time, stack, hh_table, hash_history, do_null);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -498,6 +498,11 @@ int alphabeta(Position &pos,
                 return beta;
             }
         }
+
+        // Razoring
+        if (depth < 3 && !in_check && static_eval + depth * 300 < alpha) {
+            return alphabeta(pos, alpha, beta, 0, ply, stop_time, stack, hash_history, do_null);
+        }
     }
 
     // TT Probing


### PR DESCRIPTION
```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw   White   Black
   0 4ku2-master                   -25       5   15000    4869    5944    4187   6962.5   46.4%   27.9%   55.2%   37.6%
   1 4ku2-1-300                     30      12    2500    1008     795     697   1356.5   54.3%   27.9%   63.7%   44.8%
   2 4ku2-1-200                     27      12    2500    1011     818     671   1346.5   53.9%   26.8%   62.4%   45.3%
   3 4ku2-3-200                     26      12    2500     986     802     712   1342.0   53.7%   28.5%   60.8%   46.6%
   4 4ku2-2-300                     25      11    2500     972     792     736   1340.0   53.6%   29.4%   62.8%   44.4%
   5 4ku2-2-200                     22      12    2500     985     828     687   1328.5   53.1%   27.5%   63.8%   42.4%
   6 4ku2-3-300                     21      12    2500     982     834     684   1324.0   53.0%   27.4%   60.8%   45.1%
```

TC: 10+0.1
UHO book

Left overnight to do some tuning, it's all within margin. But I guess we're still doing the top one, which is also the safest one, razoring at depth 1 with 300 margin, which is +30 +- 12

```
-rwxrwx--- 1 root vboxsf  5309 Nov 27 22:47 4ku2-compressed*
-rwxrwx--- 1 root vboxsf  3434 Nov 27 22:47 4ku2-compressed-mini*
-rwxrwx--- 1 root vboxsf 22798 Nov 27 22:47 4ku2-normal*
-rwxrwx--- 1 root vboxsf  8292 Nov 27 22:47 4ku2-normal-mini*
-rwxrwx--- 1 root vboxsf 38088 Nov 27 22:47 4ku-executable*
-rwxrwx--- 1 root vboxsf 47352 Nov 27 22:47 4ku-executable-mini*
```

3434 - 3408 = 26 bytes