### PR TITLE
Add lazy smp

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-3,419 bytes
+3,416 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-3,416 bytes
+3,408 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-3,433 bytes
+3,419 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-3,312 bytes
+3,433 bytes
 ```
 
 ---

--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,8 @@ python3 ../minifier/minify.py ../src/main.cpp > ../src/main-mini.cpp
 ######################## Minify Code ########################
 
 
-c++ ../src/main.cpp -O3 -Wall -Wextra -Wconversion -Wno-misleading-indentation -o 4ku-executable
-c++ ../src/main-mini.cpp -O3 -Wall -Wextra -Wconversion -Wno-misleading-indentation -o 4ku-executable-mini
+c++ ../src/main.cpp -O3 -Wall -Wextra -Wconversion -Wno-misleading-indentation -pthread -o 4ku-executable
+c++ ../src/main-mini.cpp -O3 -Wall -Wextra -Wconversion -Wno-misleading-indentation -pthread -o 4ku-executable-mini
 
 
 ######################## Normal Version ########################

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -350,7 +350,6 @@ def rename(tokens):
         "hh_table":"dc",
         "thread_count": "de",
         "threads": "df",
-        "helper_id": "dg",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -376,7 +376,7 @@ def rename(tokens):
         "east":"by",
         "west":"bz",
         "now":"ca",
-        "iterative_deepen": "dd",
+        "iteratively_deepen": "dd",
         # Macros
         "MATE_SCORE":"af",
         "INF":"ag",

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -348,6 +348,9 @@ def rename(tokens):
         "protected_by_pawns":"da",
         "piece_bb":"db",
         "hh_table":"dc",
+        "thread_count": "dd",
+        "threads": "de",
+        "helper_id": "df",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -348,9 +348,9 @@ def rename(tokens):
         "protected_by_pawns":"da",
         "piece_bb":"db",
         "hh_table":"dc",
-        "thread_count": "dd",
-        "threads": "de",
-        "helper_id": "df",
+        "thread_count": "de",
+        "threads": "df",
+        "helper_id": "dg",
         # Labels
         "do_search":"bk",
         "full_search":"bl",
@@ -377,6 +377,7 @@ def rename(tokens):
         "east":"by",
         "west":"bz",
         "now":"ca",
+        "iterative_deepen": "dd",
         # Macros
         "MATE_SCORE":"af",
         "INF":"ag",

--- a/src/launcher-compressed.sh
+++ b/src/launcher-compressed.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 T=`mktemp`
-tail -c +116 "$0"|lzma -d|g++ -xc++ -O3 - -o /dev/fd/1>$T
+tail -c +116 "$0"|lzma -d|g++ -xc++ -O3 -pthread - -o /dev/fd/1>$T
 chmod +x $T
 (sleep 3;rm $T)&exec $T

--- a/src/launcher-compressed.sh
+++ b/src/launcher-compressed.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 T=`mktemp`
-tail -c +116 "$0"|lzma -d|g++ -xc++ -O3 -pthread - -o /dev/fd/1>$T
+tail -c +125 "$0"|lzma -d|g++ -xc++ -O3 -pthread - -o /dev/fd/1>$T
 chmod +x $T
 (sleep 3;rm $T)&exec $T

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 T=`mktemp`
-tail -c +108 "$0"|g++ -xc++ -O3 - -o /dev/fd/1>$T
+tail -c +108 "$0"|g++ -xc++ -O3 -pthread - -o /dev/fd/1>$T
 chmod +x $T
 (sleep 3;rm $T)&exec $T

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 T=`mktemp`
-tail -c +108 "$0"|g++ -xc++ -O3 -pthread - -o /dev/fd/1>$T
+tail -c +117 "$0"|g++ -xc++ -O3 -pthread - -o /dev/fd/1>$T
 chmod +x $T
 (sleep 3;rm $T)&exec $T

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,10 @@ const auto keys = []() {
     return values;
 }();
 
+// TODO: Read from UCI options
 const int MAX_TT_SIZE = 2000000;
+const int thread_count = 1;
+
 vector<TT_Entry> transposition_table;
 
 [[nodiscard]] BB flip(const BB bb) {
@@ -663,7 +666,6 @@ int main() {
             cin >> btime;
             const auto stop_time = now() + (pos.flipped ? btime : wtime) / 30;
 
-            const int thread_count = 1;  // TODO: Read from UCI options
             vector<thread> threads;
             for (int i = 1; i < thread_count; ++i) {
                 threads.emplace_back([=]() mutable { iterative_deepen(pos, hash_history, stop_time); });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -663,7 +663,7 @@ int main() {
             cin >> btime;
             const auto stop_time = now() + (pos.flipped ? btime : wtime) / 30;
 
-            const int thread_count = 2;  // TODO: Read from UCI options
+            const int thread_count = 1;  // TODO: Read from UCI options
             auto threads = vector<thread>();
             for (int helper_id = 1; helper_id < thread_count; helper_id++) {
                 threads.emplace_back([=]() mutable { iterative_deepen(pos, hash_history, stop_time); });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -665,12 +665,12 @@ int main() {
 
             const int thread_count = 1;  // TODO: Read from UCI options
             vector<thread> threads;
-            for (int helper_id = 1; helper_id < thread_count; helper_id++) {
+            for (int i = 1; i < thread_count; ++i) {
                 threads.emplace_back([=]() mutable { iterative_deepen(pos, hash_history, stop_time); });
             }
             const auto best_move = iterative_deepen(pos, hash_history, stop_time);
-            for (int helper_id = 1; helper_id < thread_count; helper_id++) {
-                threads[helper_id - 1].join();
+            for (int i = 1; i < thread_count; ++i) {
+                threads[i - 1].join();
             }
 
             cout << "bestmove " << move_str(best_move, pos.flipped) << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,7 @@ const auto keys = []() {
     return values;
 }();
 
-// TODO: Read from UCI options
+// Engine options
 const int MAX_TT_SIZE = 2000000;
 const int thread_count = 1;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -669,9 +669,9 @@ int main() {
             // Lazy SMP
             vector<thread> threads;
             for (int i = 1; i < thread_count; ++i) {
-                threads.emplace_back([=]() mutable { iterative_deepen(pos, hash_history, stop_time); });
+                threads.emplace_back([=]() mutable { iteratively_deepen(pos, hash_history, stop_time); });
             }
-            const auto best_move = iterative_deepen(pos, hash_history, stop_time);
+            const auto best_move = iteratively_deepen(pos, hash_history, stop_time);
             for (int i = 1; i < thread_count; ++i) {
                 threads[i - 1].join();
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -664,7 +664,7 @@ int main() {
             const auto stop_time = now() + (pos.flipped ? btime : wtime) / 30;
 
             const int thread_count = 1;  // TODO: Read from UCI options
-            auto threads = vector<thread>();
+            vector<thread> threads;
             for (int helper_id = 1; helper_id < thread_count; helper_id++) {
                 threads.emplace_back([=]() mutable { iterative_deepen(pos, hash_history, stop_time); });
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -666,6 +666,7 @@ int main() {
             cin >> btime;
             const auto stop_time = now() + (pos.flipped ? btime : wtime) / 30;
 
+            // Lazy SMP
             vector<thread> threads;
             for (int i = 1; i < thread_count; ++i) {
                 threads.emplace_back([=]() mutable { iterative_deepen(pos, hash_history, stop_time); });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -625,7 +625,7 @@ int alphabeta(Position &pos,
     return alpha;
 }
 
-Move iterative_deepen(Position &pos, vector<uint64_t> &hash_history, const int64_t stop_time) {
+Move iteratively_deepen(Position &pos, vector<uint64_t> &hash_history, const int64_t stop_time) {
     Move best_move;
     Stack stack[128];
     uint64_t hh_table[64][64] = {};


### PR DESCRIPTION
1 thread, 1+0.01, UHO book:
```
Score of 4ku2 vs 4ku2-master: 1179 - 1157 - 664  [0.504] 3000
...      4ku2 playing White: 688 - 484 - 328  [0.568] 1500
...      4ku2 playing Black: 491 - 673 - 336  [0.439] 1500
...      White vs Black: 1361 - 975 - 664  [0.564] 3000
Elo difference: 2.5 +/- 11.0, LOS: 67.6 %, DrawRatio: 22.1 %
```

2 threads, 1+0.01, UHO book:
```
Score of 4ku2 vs 4ku2-master: 633 - 540 - 327  [0.531] 1500
...      4ku2 playing White: 368 - 217 - 165  [0.601] 750
...      4ku2 playing Black: 265 - 323 - 162  [0.461] 750
...      White vs Black: 691 - 482 - 327  [0.570] 1500
Elo difference: 21.6 +/- 15.6, LOS: 99.7 %, DrawRatio: 21.8 %
```

2 threads, 5+0.5, UHO book:
```
Score of 4ku2 vs 4ku2-master: 318 - 187 - 195  [0.594] 700
...      4ku2 playing White: 193 - 71 - 86  [0.674] 350
...      4ku2 playing Black: 125 - 116 - 109  [0.513] 350
...      White vs Black: 309 - 196 - 195  [0.581] 700
Elo difference: 65.8 +/- 22.1, LOS: 100.0 %, DrawRatio: 27.9 %
```

4 threads, 1+0.01, UHO book:
```
Score of 4ku2 vs 4ku2-master: 666 - 484 - 350  [0.561] 1500
...      4ku2 playing White: 384 - 192 - 174  [0.628] 750
...      4ku2 playing Black: 282 - 292 - 176  [0.493] 750
...      White vs Black: 676 - 474 - 350  [0.567] 1500
Elo difference: 42.4 +/- 15.5, LOS: 100.0 %, DrawRatio: 23.3 %
```

12 threads, 1+0.01, UHO book:
```
Score of 4ku2 vs 4ku2-master: 515 - 262 - 223  [0.626] 1000
...      4ku2 playing White: 287 - 97 - 116  [0.690] 500
...      4ku2 playing Black: 228 - 165 - 107  [0.563] 500
...      White vs Black: 452 - 325 - 223  [0.564] 1000
Elo difference: 89.9 +/- 19.4, LOS: 100.0 %, DrawRatio: 22.3 %
```

12 threads, 10+0.1, UHO book:
```
Score of 4ku2 vs 4ku2-master: 147 - 39 - 64  [0.716] 250
...      4ku2 playing White: 90 - 9 - 26  [0.824] 125
...      4ku2 playing Black: 57 - 30 - 38  [0.608] 125
...      White vs Black: 120 - 66 - 64  [0.608] 250
Elo difference: 160.6 +/- 39.7, LOS: 100.0 %, DrawRatio: 25.6 %
```

Scaling test:
```
1T: info score cp 16 depth 12 nodes 27359273 time 11244 nps 2433233
2T: info score cp 16 depth 12 nodes 16629340 time 7188 nps 2313486
4T: info score cp 16 depth 12 nodes 16552006 time 7455 nps 2220255
8T: info score cp 16 depth 12 nodes 8473243 time 4260 nps 1989024
12T: info score cp 16 depth 12 nodes 7644381 time 3987 nps 1917326
```

```
-rwxrwx--- 1 root vboxsf  5262 Nov 27 19:16 4ku2-compressed*
-rwxrwx--- 1 root vboxsf  3408 Nov 27 19:16 4ku2-compressed-mini*
-rwxrwx--- 1 root vboxsf 22579 Nov 27 19:16 4ku2-normal*
-rwxrwx--- 1 root vboxsf  8225 Nov 27 19:16 4ku2-normal-mini*
-rwxrwx--- 1 root vboxsf 38088 Nov 27 19:16 4ku-executable*
-rwxrwx--- 1 root vboxsf 37656 Nov 27 19:16 4ku-executable-mini*
```

3408-3312 = 96 bytes