### PR TITLE
Smaller executables

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,11 @@ python3 ../minifier/minify.py ../src/main.cpp > ../src/main-mini.cpp
 ######################## Minify Code ########################
 
 
-c++ ../src/main.cpp -O3 -Wall -Wextra -Wconversion -Wno-misleading-indentation -pthread -o 4ku-executable
-c++ ../src/main-mini.cpp -O3 -Wall -Wextra -Wconversion -Wno-misleading-indentation -pthread -o 4ku-executable-mini
+c++ ../src/main.cpp -O3 -Wall -Wextra -Wconversion -Wno-misleading-indentation -pthread -o 4ku2-executable
+strip -s 4ku2-executable
+
+c++ ../src/main-mini.cpp -O3 -Wall -Wextra -Wconversion -Wno-misleading-indentation -pthread -o 4ku2-executable-mini
+strip -s 4ku2-executable-mini
 
 
 ######################## Normal Version ########################


### PR DESCRIPTION
I guess not the point of 4ku2 but anything build being smaller = better imo.

Before:
```
-rwxrwx--- 1 root vboxsf  5384 Nov 28 15:18 4ku2-compressed*
-rwxrwx--- 1 root vboxsf  3497 Nov 28 15:18 4ku2-compressed-mini*
-rwxrwx--- 1 root vboxsf 23133 Nov 28 15:18 4ku2-normal*
-rwxrwx--- 1 root vboxsf  8424 Nov 28 15:18 4ku2-normal-mini*
-rwxrwx--- 1 root vboxsf 38128 Nov 28 15:18 4ku-executable*
-rwxrwx--- 1 root vboxsf 47376 Nov 28 15:18 4ku-executable-mini*
```

After:
```
-rwxrwx--- 1 root vboxsf  5384 Nov 28 15:20 4ku2-compressed*
-rwxrwx--- 1 root vboxsf  3497 Nov 28 15:20 4ku2-compressed-mini*
-rwxrwx--- 1 root vboxsf 30944 Nov 28 15:20 4ku2-executable*
-rwxrwx--- 1 root vboxsf 39248 Nov 28 15:20 4ku2-executable-mini*
-rwxrwx--- 1 root vboxsf 23133 Nov 28 15:20 4ku2-normal*
-rwxrwx--- 1 root vboxsf  8424 Nov 28 15:20 4ku2-normal-mini*
```

Bonus: executables now have the same hash between builds. Also fixed naming to be consistent.