### PR TITLE
Use partial search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sh build.sh
 
 ## Size
 ```
-3,494 bytes
+3,488 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -599,7 +599,7 @@ int alphabeta(Position &pos,
             }
         }
 
-        // Stop move loop if out of time
+        // Exit early if out of time
         if (now() >= stop_time) {
             return 0;
         }
@@ -634,13 +634,13 @@ int alphabeta(Position &pos,
 
     // Save to TT
     if (!in_qsearch && (tt_entry.key != tt_key || depth >= tt_entry.depth || tt_flag == 0)) {
-        tt_entry = TT_Entry{tt_key, best_move, best_score, depth, tt_flag};
+        tt_entry = TT_Entry{ tt_key, best_move, best_score, depth, tt_flag };
     }
 
     return alpha;
 }
 
-Move iteratively_deepen(Position &pos, vector<uint64_t> &hash_history, const int64_t stop_time) {
+Move iteratively_deepen(Position& pos, vector<uint64_t>& hash_history, const int64_t stop_time) {
     Stack stack[128] = {};
     uint64_t hh_table[64][64] = {};
     for (int i = 1; i < 128; ++i) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -599,6 +599,11 @@ int alphabeta(Position &pos,
             }
         }
 
+        // Stop move loop if out of time
+        if (now() >= stop_time) {
+            return 0;
+        }
+
         if (score > best_score) {
             best_score = score;
             best_move = move;
@@ -627,8 +632,8 @@ int alphabeta(Position &pos,
         return in_check ? ply - MATE_SCORE : 0;
     }
 
-    // Save to TT if didn't run out of time
-    if (!in_qsearch && (tt_entry.key != tt_key || depth >= tt_entry.depth || tt_flag == 0) && now() < stop_time) {
+    // Save to TT
+    if (!in_qsearch && (tt_entry.key != tt_key || depth >= tt_entry.depth || tt_flag == 0)) {
         tt_entry = TT_Entry{tt_key, best_move, best_score, depth, tt_flag};
     }
 
@@ -636,7 +641,6 @@ int alphabeta(Position &pos,
 }
 
 Move iteratively_deepen(Position &pos, vector<uint64_t> &hash_history, const int64_t stop_time) {
-    Move best_move;
     Stack stack[128] = {};
     uint64_t hh_table[64][64] = {};
     for (int i = 1; i < 128; ++i) {
@@ -644,9 +648,8 @@ Move iteratively_deepen(Position &pos, vector<uint64_t> &hash_history, const int
         if (now() >= stop_time) {
             break;
         }
-        best_move = stack[0].move;
     }
-    return best_move;
+    return stack[0].move;
 }
 
 int main() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -634,13 +634,13 @@ int alphabeta(Position &pos,
 
     // Save to TT
     if (!in_qsearch && (tt_entry.key != tt_key || depth >= tt_entry.depth || tt_flag == 0)) {
-        tt_entry = TT_Entry{ tt_key, best_move, best_score, depth, tt_flag };
+        tt_entry = TT_Entry{tt_key, best_move, best_score, depth, tt_flag};
     }
 
     return alpha;
 }
 
-Move iteratively_deepen(Position& pos, vector<uint64_t>& hash_history, const int64_t stop_time) {
+Move iteratively_deepen(Position &pos, vector<uint64_t> &hash_history, const int64_t stop_time) {
     Stack stack[128] = {};
     uint64_t hh_table[64][64] = {};
     for (int i = 1; i < 128; ++i) {


### PR DESCRIPTION
```
Score of 4ku2 vs 4ku2-master: 2214 - 1687 - 1099  [0.553] 5000
...      4ku2 playing White: 1318 - 656 - 527  [0.632] 2501
...      4ku2 playing Black: 896 - 1031 - 572  [0.473] 2499
...      White vs Black: 2349 - 1552 - 1099  [0.580] 5000
Elo difference: 36.8 +/- 8.5, LOS: 100.0 %, DrawRatio: 22.0 %
```
1+0.01 UHO book

```
Score of 4ku2 vs 4ku2-master: 396 - 286 - 318  [0.555] 1000
...      4ku2 playing White: 227 - 108 - 165  [0.619] 500
...      4ku2 playing Black: 169 - 178 - 153  [0.491] 500
...      White vs Black: 405 - 277 - 318  [0.564] 1000
Elo difference: 38.4 +/- 17.8, LOS: 100.0 %, DrawRatio: 31.8 %
```
10+0.1 UHO book

```
-rwxrwx--- 1 root vboxsf  5379 Nov 29 22:19 4ku2-compressed*
-rwxrwx--- 1 root vboxsf  3488 Nov 29 22:19 4ku2-compressed-mini*
-rwxrwx--- 1 root vboxsf 30944 Nov 28 15:20 4ku2-executable*
-rwxrwx--- 1 root vboxsf 39248 Nov 28 15:20 4ku2-executable-mini*
-rwxrwx--- 1 root vboxsf 23151 Nov 29 22:19 4ku2-normal*
-rwxrwx--- 1 root vboxsf  8418 Nov 29 22:19 4ku2-normal-mini*
-rwxrwx--- 1 root vboxsf 38128 Nov 29 22:19 4ku-executable*
-rwxrwx--- 1 root vboxsf 47368 Nov 29 22:19 4ku-executable-mini*
```

3488 - 3494 = -6 bytes