### PR TITLE
Capture only movegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No small version of 4ku is currently available on Windows.
 
 ## Size
 ```
-3,595 bytes
+3,592 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No small version of 4ku is currently available on Windows.
 
 ## Size
 ```
-3,575 bytes
+3,595 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -385,6 +385,7 @@ def rename(tokens):
         "allocated_time":"dk",
         "stops":"dl",
         "stop":"dm",
+        "only_captures":"dn",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -304,7 +304,7 @@ void generate_piece_moves(Move *const movelist,
     }
 }
 
-[[nodiscard]] int movegen(const Position &pos, Move *const movelist, bool only_captures = false) {
+[[nodiscard]] int movegen(const Position &pos, Move *const movelist, const bool only_captures) {
     int num_moves = 0;
     const BB all = pos.colour[0] | pos.colour[1];
     const BB to_mask = only_captures ? pos.colour[1] : ~pos.colour[0];
@@ -757,7 +757,7 @@ int main() {
             pos = Position();
             hash_history.clear();
         } else {
-            const int num_moves = movegen(pos, moves);
+            const int num_moves = movegen(pos, moves, false);
             for (int i = 0; i < num_moves; ++i) {
                 if (word == move_str(moves[i], pos.flipped)) {
                     if (piece_on(pos, moves[i].to) != None || piece_on(pos, moves[i].from) == Pawn) {


### PR DESCRIPTION
This is mostly for speedup reasons and preparations for SEE, but I guess it also allows en-passant to be searched in qsearch.

1+0.01 UHO book:
```
Score of 4ku2 vs 4ku2-master: 1974 - 1500 - 1526  [0.547] 5000
...      4ku2 playing White: 1151 - 624 - 725  [0.605] 2500
...      4ku2 playing Black: 823 - 876 - 801  [0.489] 2500
...      White vs Black: 2027 - 1447 - 1526  [0.558] 5000
Elo difference: 33.0 +/- 8.0, LOS: 100.0 %, DrawRatio: 30.5 %
```

10+0.1 UHO book:
```
Score of 4ku2 vs 4ku2-master: 458 - 366 - 476  [0.535] 1300
...      4ku2 playing White: 301 - 123 - 226  [0.637] 650
...      4ku2 playing Black: 157 - 243 - 250  [0.434] 650
...      White vs Black: 544 - 280 - 476  [0.602] 1300
Elo difference: 24.6 +/- 15.0, LOS: 99.9 %, DrawRatio: 36.6 %
```

3592 - 3575 = 17 bytes