### PR TITLE
Fix lazy smp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No small version of 4ku is currently available on Windows.
 
 ## Size
 ```
-3,592 bytes
+3,588 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -723,9 +723,8 @@ int main() {
 
             // Lazy SMP
             vector<thread> threads;
-            vector<int> stops = {false};
+            vector<int> stops(thread_count, false);
             for (int i = 1; i < thread_count; ++i) {
-                stops.emplace_back(false);
                 threads.emplace_back([=, &stops]() mutable {
                     iteratively_deepen(pos,
                                        hash_history,


### PR DESCRIPTION
This fixes an issue introduced with TM changes where lazy SMP would previously only work reliably up to 4 threads.

10+0.1 fixed version 12 threads vs 1 thread master, UHO book:
```
Score of 4ku2 vs 4ku2-master: 89 - 18 - 43  [0.737] 150
...      4ku2 playing White: 54 - 6 - 15  [0.820] 75
...      4ku2 playing Black: 35 - 12 - 28  [0.653] 75
...      White vs Black: 66 - 41 - 43  [0.583] 150
Elo difference: 178.7 +/- 50.6, LOS: 100.0 %, DrawRatio: 28.7 %
```

3588 - 3592 = -4 bytes