### PR TITLE
More UCI info

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -735,17 +735,16 @@ Move iteratively_deepen(Position &pos,
 
         // minify delete on
         if (thread_id == 0) {
-            auto elapsed = now() - start_time;
-            if (elapsed == 0) {
-                elapsed = 1;
-            }
+            const auto elapsed = now() - start_time;
 
             cout << "info";
             cout << " depth " << i;
             cout << " score cp " << score;
             cout << " time " << elapsed;
             cout << " nodes " << nodes;
-            cout << " nps " << nodes * 1000 / elapsed;
+            if (elapsed > 0) {
+                cout << " nps " << nodes * 1000 / elapsed;
+            }
             cout << " pv " << move_str(stack[0].move, pos.flipped);
             cout << endl;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ const auto keys = []() {
 
 // Engine options
 const int MAX_TT_SIZE = 2000000;
-const int thread_count = 12;
+const int thread_count = 1;
 
 vector<TT_Entry> transposition_table;
 


### PR DESCRIPTION
Before:
```
info depth 1 score cp 37 pv b1c3
info depth 2 score cp 10 pv b1c3
info depth 3 score cp 37 pv b1c3
info depth 4 score cp 10 pv b1c3
info depth 5 score cp 30 pv b1c3
info depth 6 score cp 10 pv b1c3
info depth 7 score cp 37 pv b1c3
info depth 8 score cp 15 pv e2e4
info depth 9 score cp 32 pv e2e4
info depth 10 score cp 27 pv e2e4
info depth 11 score cp 28 pv e2e4
info depth 12 score cp 34 pv e2e4
info depth 13 score cp 24 pv e2e4
```

After:
```
info depth 1 score cp 37 time 1 nodes 20 nps 20000 pv b1c3
info depth 2 score cp 10 time 1 nodes 115 nps 115000 pv b1c3
info depth 3 score cp 37 time 1 nodes 696 nps 696000 pv b1c3
info depth 4 score cp 10 time 3 nodes 2470 nps 823333 pv b1c3
info depth 5 score cp 30 time 5 nodes 6096 nps 1219200 pv b1c3
info depth 6 score cp 10 time 14 nodes 26685 nps 1906071 pv b1c3
info depth 7 score cp 37 time 33 nodes 69463 nps 2104939 pv b1c3
info depth 8 score cp 15 time 135 nodes 318608 nps 2360059 pv e2e4
info depth 9 score cp 32 time 239 nodes 572846 nps 2396845 pv e2e4
info depth 10 score cp 27 time 482 nodes 1165552 nps 2418157 pv e2e4
info depth 11 score cp 28 time 929 nodes 2245258 nps 2416854 pv e2e4
info depth 12 score cp 34 time 2599 nodes 6301876 nps 2424731 pv e2e4
info depth 13 score cp 24 time 5264 nodes 12711410 nps 2414781 pv e2e4
info depth 14 score cp 18 time 11825 nodes 28077624 nps 2374429 pv e2e4
```

Same size