### PR TITLE
Simplify history

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No small version of 4ku is currently available on Windows.
 
 ## Size
 ```
-3,586 bytes
+3,582 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No small version of 4ku is currently available on Windows.
 
 ## Size
 ```
-3,582 bytes
+3,575 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -579,18 +579,16 @@ int alphabeta(Position &pos,
     // Score moves
     int64_t move_scores[256];
     for (int j = 0; j < num_moves; ++j) {
-        int64_t move_score;
         const int capture = piece_on(pos, moves[j].to);
         if (moves[j] == tt_move) {
-            move_score = 1LL << 62;
+            move_scores[j] = 1LL << 62;
         } else if (capture != None) {
-            move_score = ((capture + 1) * (1LL << 54)) - piece_on(pos, moves[j].from);
+            move_scores[j] = ((capture + 1) * (1LL << 54)) - piece_on(pos, moves[j].from);
         } else if (moves[j] == stack[ply].killer) {
-            move_score = 1LL << 50;
+            move_scores[j] = 1LL << 50;
         } else {
-            move_score = hh_table[moves[j].from][moves[j].to];
+            move_scores[j] = hh_table[moves[j].from][moves[j].to];
         }
-        move_scores[j] = move_score;
     }
 
     int moves_evaluated = 0;


### PR DESCRIPTION
1+0.01 UHO book:
```
Score of 4ku2 vs 4ku2-master: 2401 - 2117 - 1982  [0.522] 6500
...      4ku2 playing White: 1424 - 844 - 983  [0.589] 3251
...      4ku2 playing Black: 977 - 1273 - 999  [0.454] 3249
...      White vs Black: 2697 - 1821 - 1982  [0.567] 6500
Elo difference: 15.2 +/- 7.0, LOS: 100.0 %, DrawRatio: 30.5 %
```

10+0.1 UHO book:
```
Score of 4ku2 vs 4ku2-master: 1847 - 1615 - 2038  [0.521] 5500
...      4ku2 playing White: 1176 - 584 - 990  [0.608] 2750
...      4ku2 playing Black: 671 - 1031 - 1048  [0.435] 2750
...      White vs Black: 2207 - 1255 - 2038  [0.587] 5500
Elo difference: 14.7 +/- 7.3, LOS: 100.0 %, DrawRatio: 37.1 %
```

3575 - 3586 = -11 bytes