### PR TITLE
Tighter razoring

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -541,7 +541,7 @@ int alphabeta(Position &pos,
             }
 
             // Razoring
-            if (depth == 1 && static_eval + 300 < alpha) {
+            if (depth == 1 && static_eval + 200 < alpha) {
                 return alphabeta(pos,
                                  alpha,
                                  beta,


### PR DESCRIPTION
```
ELO   | 3.54 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 39112 W: 12876 L: 12477 D: 13759
```

http://chess.grantnet.us/test/29809/

0 bytes