### PR TITLE
Reverse futility pruning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,598 bytes
+3,605 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -412,6 +412,7 @@ def rename(tokens):
         "stops":"dl",
         "stop":"dm",
         "only_captures":"dn",
+        "margins":"dp",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -512,7 +512,7 @@ int alphabeta(Position &pos,
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
             if (depth < 5) {
-                const int margins[] = { 0, 100, 200, 400, 800 };
+                const int margins[] = {0, 100, 200, 400, 800};
                 if (static_eval - margins[depth] >= beta) {
                     return beta;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -511,9 +511,9 @@ int alphabeta(Position &pos,
 
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
-            if (depth < 3) {
-                const int margin = 120;
-                if (static_eval - margin * depth >= beta) {
+            if (depth < 5) {
+                const int margins[] = { 0, 100, 200, 400, 800 };
+                if (static_eval - margins[depth] >= beta) {
                     return beta;
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -517,8 +517,9 @@ int alphabeta(Position &pos,
                     return beta;
                 }
             }
+
             // Null move pruning
-            else if (static_eval >= beta && do_null) {
+            if (depth > 2 && static_eval >= beta && do_null) {
                 auto npos = pos;
                 flip(npos);
                 npos.ep = 0;


### PR DESCRIPTION
```
ELO   | 10.09 +- 6.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6648 W: 2241 L: 2048 D: 2359
```

http://chess.grantnet.us/test/29810/

3605 - 3598 = 7 bytes
