### PR TITLE
Make nullmove use R=3.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -537,7 +537,7 @@ int alphabeta(Position &pos,
                 if (-alphabeta(npos,
                                -beta,
                                -beta + 1,
-                               depth - 3,
+                               depth - 4,
                                ply + 1,
                                // minify delete on
                                nodes,


### PR DESCRIPTION
Because we need to reduce depth by one for the recursion, we're currently really only using R=2. It's not the 1990's any more, so use R=3.

5+0.5 test:

Elo difference: 18.9 +/- 10.3, LOS: 100.0 %, DrawRatio: 41.4 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted