### PR TITLE
Make futility pruning much more aggressive.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -523,7 +523,7 @@ int alphabeta(Position &pos,
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
             if (depth < 5) {
-                const int margins[] = {0, 100, 200, 400, 800};
+                const int margins[] = {0, 50, 100, 200, 300};
                 if (static_eval - margins[depth] >= beta) {
                     return beta;
                 }


### PR DESCRIPTION
Score of 4ku vs master: 1456 - 1300 - 1836  [0.517] 4592
...      4ku playing White: 811 - 590 - 896  [0.548] 2297
...      4ku playing Black: 645 - 710 - 940  [0.486] 2295
...      White vs Black: 1521 - 1235 - 1836  [0.531] 4592
Elo difference: 11.8 +/- 7.8, LOS: 99.9 %, DrawRatio: 40.0 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted