### PR TITLE
Support and attack passed pawns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,720 bytes
+3,777 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -413,6 +413,8 @@ def rename(tokens):
         "stop":"dm",
         "only_captures":"dn",
         "margins":"dp",
+        "my_k_pos":"dq",
+        "their_k_pos":"dr",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,6 +372,9 @@ const int king_shield[] = {S(24, -11), S(12, -16)};
         const BB pawns[] = {pos.colour[0] & pos.pieces[Pawn], pos.colour[1] & pos.pieces[Pawn]};
         const BB protected_by_pawns = nw(pawns[0]) | ne(pawns[0]);
 
+        const auto my_k_pos = lsb(pos.colour[0] & pos.pieces[King]);
+        const auto their_k_pos = lsb(pos.colour[1] & pos.pieces[King]);
+
         // Bishop pair
         if (count(pos.colour[0] & pos.pieces[Bishop]) == 2) {
             score += bishop_pair;
@@ -418,6 +421,17 @@ const int king_shield[] = {S(24, -11), S(12, -16)};
                         if (north(piece_bb) & pos.colour[1]) {
                             score += pawn_passed_blocked;
                         }
+
+                        // King defense/attack
+                        // king distance to square in front of passer
+                        score -=
+                            S(0, 1) * (rank - 1)
+                            * max(abs((my_k_pos / 8) - (rank + 1)),
+                                  abs((my_k_pos % 8) - file));
+                        score +=
+                            S(0, 3) * (rank - 1)
+                            * max(abs((their_k_pos / 8) - (rank + 1)),
+                                  abs((their_k_pos % 8) - file));
                     }
 
                     // Doubled pawns

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -425,13 +425,9 @@ const int king_shield[] = {S(24, -11), S(12, -16)};
                         // King defense/attack
                         // king distance to square in front of passer
                         score -=
-                            S(0, 1) * (rank - 1)
-                            * max(abs((my_k_pos / 8) - (rank + 1)),
-                                  abs((my_k_pos % 8) - file));
-                        score +=
-                            S(0, 3) * (rank - 1)
-                            * max(abs((their_k_pos / 8) - (rank + 1)),
-                                  abs((their_k_pos % 8) - file));
+                            S(0, 1) * (rank - 1) * max(abs((my_k_pos / 8) - (rank + 1)), abs((my_k_pos % 8) - file));
+                        score += S(0, 3) * (rank - 1) *
+                                 max(abs((their_k_pos / 8) - (rank + 1)), abs((their_k_pos % 8) - file));
                     }
 
                     // Doubled pawns


### PR DESCRIPTION
Score of 4ku vs master: 1050 - 898 - 1114  [0.525] 3062
...      4ku playing White: 568 - 399 - 564  [0.555] 1531
...      4ku playing Black: 482 - 499 - 550  [0.494] 1531
...      White vs Black: 1067 - 881 - 1114  [0.530] 3062
Elo difference: 17.3 +/- 9.8, LOS: 100.0 %, DrawRatio: 36.4 %
SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted