### PR TITLE
Bad bishop eval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,943 bytes
+3,985 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,6 +382,7 @@ const int rook_semi_open = S(35, 11);
 const int rook_rank78 = S(34, 1);
 const int king_shield[] = {S(36, -13), S(16, -15), S(-89, 30)};
 const int pawn_attacked[] = {S(-64, -14), S(-55, -42)};
+const int bad_bishop = S(-4, -4);
 
 [[nodiscard]] int eval(Position &pos) {
     // Include side to move bonus
@@ -458,6 +459,15 @@ const int pawn_attacked[] = {S(-64, -14), S(-55, -42)};
                     // Doubled pawns
                     if ((north(piece_bb) | north(north(piece_bb))) & pawns[0]) {
                         score += pawn_doubled;
+                    }
+
+                    // Bad bishop (considering which color we sit on)
+                    auto colour_mask = 0xAA55AA55AA55AA55ULL;
+                    if ((file + rank) & 1) {
+                        colour_mask = ~colour_mask;
+                    }
+                    if (pos.colour[0] & pos.pieces[Bishop] & colour_mask) {
+                        score += bad_bishop;
                     }
                 } else if (p == Rook) {
                     // Rook on open or semi-open files


### PR DESCRIPTION
Score of 4ku vs master: 2896 - 2705 - 3565  [0.510] 9166
...      4ku playing White: 1575 - 1218 - 1790  [0.539] 4583
...      4ku playing Black: 1321 - 1487 - 1775  [0.482] 4583
...      White vs Black: 3062 - 2539 - 3565  [0.529] 9166
Elo difference: 7.2 +/- 5.6, LOS: 99.5 %, DrawRatio: 38.9 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted