### PR TITLE
Enable TT in qsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,817 bytes
+3,820 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -719,7 +719,7 @@ int alphabeta(Position &pos,
     }
     hash_history.pop_back();
 
-    // Return mate or draw scores if no moves found and not in qsearch
+    // Return mate or draw scores if no moves found
     if (best_score == -INF) {
         return in_qsearch ? alpha : in_check ? ply - MATE_SCORE : 0;
     }


### PR DESCRIPTION
```
ELO   | 5.49 +- 4.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 15872 W: 5221 L: 4970 D: 5681
```

http://chess.grantnet.us/test/29856/

+3 bytes