### PR TITLE
Qsearch depth equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,820 bytes
+3,824 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -726,7 +726,7 @@ int alphabeta(Position &pos,
 
     // Save to TT
     if (tt_entry.key != tt_key || depth >= tt_entry.depth || tt_flag == 0) {
-        tt_entry = TT_Entry{tt_key, best_move, best_score, depth, tt_flag};
+        tt_entry = TT_Entry{tt_key, best_move, best_score, in_qsearch ? 0 : depth, tt_flag};
     }
 
     return alpha;


### PR DESCRIPTION
```
ELO   | 7.30 +- 5.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10288 W: 3419 L: 3203 D: 3666
```

http://chess.grantnet.us/test/29858/

+4 bytes

Also there's http://chess.grantnet.us/test/29857/ which does a similar thing and is bigger, but could help with more aggressive LMR later on, so consider switching to that in the future