### PR TITLE
Introduce improving variable in rfp

### DIFF
--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -413,6 +413,7 @@ def rename(tokens):
         "stop":"dm",
         "only_captures":"dn",
         "margins":"dp",
+        "improving":"dq",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -469,12 +469,12 @@ def rename(tokens):
             "stop": "dm",
             "only_captures": "dn",
             "margins": "dp",
-            "improving": "dv",
             "my_k_pos": "dq",
             "their_k_pos": "dr",
             "window": "ds",
             "research": "dt",
             "newscore": "du",
+            "improving": "dv",
             # Labels
             "do_search": "bk",
             "full_search": "bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -498,7 +498,7 @@ int alphabeta(Position &pos,
     stack[ply].score = static_eval;
     // Check extensions
     depth = in_check ? max(1, depth + 1) : depth;
-    bool improving = ply > 0 ? false : static_eval > stack[ply - 1].score;
+    bool improving = ply > 1 ? false : static_eval > stack[ply - 2].score;
     const int in_qsearch = depth <= 0;
 
     // TT probing

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,7 @@ struct Move {
 struct [[nodiscard]] Stack {
     Move move;
     Move killer;
+    int score;
 };
 
 struct [[nodiscard]] TT_Entry {
@@ -494,10 +495,10 @@ int alphabeta(Position &pos,
               const int do_null = true) {
     const auto in_check = attacked(pos, lsb(pos.colour[0] & pos.pieces[King]));
     const int static_eval = eval(pos);
-
+    stack[ply].score = static_eval;
     // Check extensions
     depth = in_check ? max(1, depth + 1) : depth;
-
+    bool improving = ply > 0 ? false : static_eval > stack[ply - 1].score;
     const int in_qsearch = depth <= 0;
 
     // TT probing
@@ -524,7 +525,7 @@ int alphabeta(Position &pos,
             // Reverse futility pruning
             if (depth < 5) {
                 const int margins[] = {0, 50, 100, 200, 300};
-                if (static_eval - margins[depth] >= beta) {
+                if (static_eval - margins[depth - improving] >= beta) {
                     return beta;
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -498,7 +498,7 @@ int alphabeta(Position &pos,
     stack[ply].score = static_eval;
     // Check extensions
     depth = in_check ? max(1, depth + 1) : depth;
-    bool improving = ply > 1 ? false : static_eval > stack[ply - 2].score;
+    bool improving = ply > 1 ? static_eval > stack[ply - 2].score : false;
     const int in_qsearch = depth <= 0;
 
     // TT probing

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -509,7 +509,7 @@ int alphabeta(Position &pos,
     stack[ply].score = static_eval;
     // Check extensions
     depth = in_check ? max(1, depth + 1) : depth;
-    bool improving = ply > 1 ? static_eval > stack[ply - 2].score : false;
+    bool improving = ply > 1 && static_eval > stack[ply - 2].score : false;
     const int in_qsearch = depth <= 0;
 
     // TT probing


### PR DESCRIPTION
Didn't update the readme size since this isn't meant to be currently merged, size of changes is +27 bytes
```
ELO   | 8.04 +- 5.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8944 W: 2967 L: 2760 D: 3217
```
