### PR TITLE
Remove a redundant condition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,900 bytes
+3,890 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -612,7 +612,7 @@ int alphabeta(Position &pos,
     int64_t move_scores[256];
     for (int j = 0; j < num_moves; ++j) {
         const int capture = piece_on(pos, moves[j].to);
-        if (moves[j] == tt_move && (!in_qsearch || capture != None)) {
+        if (moves[j] == tt_move) {
             move_scores[j] = 1LL << 62;
         } else if (capture != None) {
             move_scores[j] = ((capture + 1) * (1LL << 54)) - piece_on(pos, moves[j].from);


### PR DESCRIPTION
Should have no effect, confirmed on OB:

```
ELO   | -0.29 +- 1.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.30 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 89480 W: 26950 L: 27024 D: 35506
```