### PR TITLE
Penalty for unreasonable kings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,904 bytes
+3,915 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -455,6 +455,9 @@ const int king_shield[] = {S(24, -11), S(12, -16)};
                     const BB shield = file < 3 ? 0x700 : 0xE000;
                     score += count(shield & pawns[0]) * king_shield[0];
                     score += count(north(shield) & pawns[0]) * king_shield[1];
+
+                    // C3D7 = Reasonable king squares
+                    score -= !(piece_bb & 0xC3D7) * king_shield[0];
                 }
             }
         }


### PR DESCRIPTION
Score of 4ku vs master: 535 - 408 - 736  [0.538] 1679
...      4ku playing White: 297 - 182 - 361  [0.568] 840
...      4ku playing Black: 238 - 226 - 375  [0.507] 839
...      White vs Black: 523 - 420 - 736  [0.531] 1679
Elo difference: 26.3 +/- 12.4, LOS: 100.0 %, DrawRatio: 43.8 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted

```
ELO   | 9.60 +- 6.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6808 W: 2140 L: 1952 D: 2716
```