### PR TITLE
Evaluate pawn attacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,915 bytes
+3,945 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -419,6 +419,8 @@ def rename(tokens):
         "research":"dt",
         "newscore":"du",
         "max_material":"m",
+        "attacked_by_pawns":"dv",
+        "pawn_attacked":"dw",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,6 +363,7 @@ const int rook_open = S(72, 1);
 const int rook_semi_open = S(30, 12);
 const int rook_rank78 = S(40, 2);
 const int king_shield[] = {S(24, -11), S(12, -16)};
+const int pawn_attacked = S(25, 20);
 
 [[nodiscard]] int eval(Position &pos) {
     // Include side to move bonus
@@ -373,6 +374,7 @@ const int king_shield[] = {S(24, -11), S(12, -16)};
         // our pawns, their pawns
         const BB pawns[] = {pos.colour[0] & pos.pieces[Pawn], pos.colour[1] & pos.pieces[Pawn]};
         const BB protected_by_pawns = nw(pawns[0]) | ne(pawns[0]);
+        const BB attacked_by_pawns = se(pawns[1]) | sw(pawns[1]);
 
         const auto my_k_pos = lsb(pos.colour[0] & pos.pieces[King]);
         const auto their_k_pos = lsb(pos.colour[1] & pos.pieces[King]);
@@ -410,6 +412,11 @@ const int king_shield[] = {S(24, -11), S(12, -16)};
                 const BB piece_bb = 1ULL << sq;
                 if (piece_bb & protected_by_pawns) {
                     score += pawn_protection[p];
+                }
+                if (~pawns[0] & piece_bb & attacked_by_pawns) {
+                    // If we're to move, we'll just lose some options and our tempo.
+                    // If we're not to move, we lose a piece?
+                    score -= pawn_attacked * (c ? 5 : 1);
                 }
 
                 if (p == Pawn) {


### PR DESCRIPTION
Score of 4ku vs master: 647 - 517 - 896  [0.532] 2060
...      4ku playing White: 361 - 219 - 451  [0.569] 1031
...      4ku playing Black: 286 - 298 - 445  [0.494] 1029
...      White vs Black: 659 - 505 - 896  [0.537] 2060
Elo difference: 22.0 +/- 11.3, LOS: 100.0 %, DrawRatio: 43.5 %
SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted

```
ELO   | 32.72 +- 13.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1672 W: 587 L: 430 D: 655
```