### PR TITLE
Late move pruning based on quiets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,963 bytes
+3,939 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,904 bytes
+3,932 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,973 bytes
+3,970 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -419,6 +419,7 @@ def rename(tokens):
         "research":"dt",
         "newscore":"du",
         "max_material":"m",
+        "quiet_moves_evaluated":"dv",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -654,10 +654,6 @@ int alphabeta(Position &pos,
         moves[best_move_index] = moves[i];
         move_scores[best_move_index] = move_scores[i];
 
-        if (alpha == beta - 1 && !in_check && quiet_moves_evaluated > 3 + 2 * depth * depth) {
-            break;
-        }
-
         // Delta pruning
         if (in_qsearch && !in_check && static_eval + 50 + max_material[piece_on(pos, move.to)] < alpha) {
             best_score = alpha;
@@ -744,6 +740,11 @@ int alphabeta(Position &pos,
                 hh_table[pos.flipped][move.from][move.to] += depth * depth;
                 stack[ply].killer = move;
             }
+            break;
+        }
+
+        // Late move pruning based on quiet move count
+        if (!in_check && alpha == beta - 1 && quiet_moves_evaluated > 3 + 2 * depth * depth) {
             break;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -623,6 +623,7 @@ int alphabeta(Position &pos,
         }
     }
 
+    int quiet_moves_evaluated = 0;
     int moves_evaluated = 0;
     int best_score = -INF;
     Move best_move{};
@@ -642,6 +643,10 @@ int alphabeta(Position &pos,
 
         moves[best_move_index] = moves[i];
         move_scores[best_move_index] = move_scores[i];
+
+        if (alpha == beta - 1 && !in_check && quiet_moves_evaluated > 3 + 2 * depth * depth) {
+            break;
+        }
 
         // Delta pruning
         if (in_qsearch && !in_check && static_eval + 50 + max_material[piece_on(pos, move.to)] < alpha) {
@@ -698,6 +703,9 @@ int alphabeta(Position &pos,
             }
         }
         moves_evaluated++;
+        if (piece_on(pos, move.to) == None) {
+            quiet_moves_evaluated++;
+        }
 
         // Exit early if out of time
         if (stop || now() >= stop_time) {


### PR DESCRIPTION
```
ELO   | 10.92 +- 6.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5856 W: 1886 L: 1702 D: 2268
```

http://chess.grantnet.us/test/29937/

+25 bytes, probably not worth merging now