### PR TITLE
Enable C++17 compiler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ endif
 EXE := $(NAME)$(SUFFIX)
 
 all:
-	g++ ./src/main.cpp -O3 -march=native -pthread -o $(EXE)
+	g++ ./src/main.cpp -std=c++17 -O3 -march=native -pthread -o $(EXE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,13 +8,26 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 # Flags
-set(CMAKE_CXX_FLAGS "-pthread -Wall -Wextra -Wshadow -Wconversion")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wshadow -Wconversion")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native")
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    # -march=native is broken on current macOS
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+else()
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native")
+endif()
 
 # Add the executable
 add_executable(
     4ku
     main.cpp
 )
+
+target_link_libraries(4ku Threads::Threads)


### PR DESCRIPTION
Needed to compile on macOS Clang.

Which also complains about -march=native, but that's just Apple being bad, sigh.