### PR TITLE
Use a 64-bit RNG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,960 bytes
+3,952 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,15 +70,13 @@ struct [[nodiscard]] TT_Entry {
 };
 
 const auto keys = []() {
-    minstd_rand r;
+    mt19937_64 r;
 
     // pieces from 1-12 multiplied the square + ep squares + castling rights
     // 12 * 64 + 64 + 16 = 848
     array<BB, 848> values;
     for (auto &val : values) {
         val = r();
-        val <<= 32;
-        val |= r();
     }
 
     return values;


### PR DESCRIPTION
Aside from number quality(?), it saves bytes.

Sanity check:
```
ELO   | 0.60 +- 6.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 0.43 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 6400 W: 1874 L: 1863 D: 2663
```