### PR TITLE
Use a 64-bit RNG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,960 bytes
+3,955 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -10,7 +10,7 @@ def get_args():
 def get_keywords(src):
     keywords = set({"int", "short", "char", "auto", "bool", "void", "using", "namespace", "define", "else",
                     "long", "unsigned", "timespec", "struct", "class", "return", "operator", "typename", "const", "string", "goto",
-                    "uint64_t", "int64_t", "uint32_t", "int32_t", "uint16_t", "int16_t", "uint8_t", "int8_t", "minstd_rand"})
+                    "uint64_t", "int64_t", "uint32_t", "int32_t", "uint16_t", "int16_t", "uint8_t", "int8_t", "mt19937_64"})
 
     get_next = False
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,15 +70,13 @@ struct [[nodiscard]] TT_Entry {
 };
 
 const auto keys = []() {
-    minstd_rand r;
+    mt19937_64 r;
 
     // pieces from 1-12 multiplied the square + ep squares + castling rights
     // 12 * 64 + 64 + 16 = 848
     array<BB, 848> values;
     for (auto &val : values) {
         val = r();
-        val <<= 32;
-        val |= r();
     }
 
     return values;


### PR DESCRIPTION
Higher quality numbers (doesn't seem to make a difference), but also several bytes shorter.

Version with fixed minifier.