### PR TITLE
Fix namespace conflict in C++17/20.

### DIFF
--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -421,7 +421,7 @@ def rename(tokens):
         "max_material":"m",
         "attacked_by_pawns":"dv",
         "pawn_attacked":"dw",
-        "empty":"dx",
+        "no_move":"dx",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ struct Move {
     int promo = 0;
 };
 
-const Move empty{};
+const Move no_move{};
 
 struct [[nodiscard]] Stack {
     Move moves[218];
@@ -754,7 +754,7 @@ int alphabeta(Position &pos,
     // Save to TT
     if (tt_entry.key != tt_key || depth >= tt_entry.depth || tt_flag == 0) {
         tt_entry =
-            TT_Entry{tt_key, best_move == empty ? tt_move : best_move, best_score, in_qsearch ? 0 : depth, tt_flag};
+            TT_Entry{tt_key, best_move == no_move ? tt_move : best_move, best_score, in_qsearch ? 0 : depth, tt_flag};
     }
 
     return alpha;


### PR DESCRIPTION
C++17 includes ```std::empty```, and there is a ```using namespace std``` in front of the code, so we have a name clash if the compiler eagerly uses C++17 features.