### PR TITLE
Delay TT key calculation and probe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,960 bytes
+3,964 bytes
 ```
 
 ---


### PR DESCRIPTION
Given that
https://github.com/GediminasMasaitis/4ku/commit/b0997e0054470dc27a22214bb848cf240ee0d6ba surprisingly failed with ```-11```, I wanted to see why that is, because it makes little sense. One possible reason is that get_pos() which calculates the TT key is pretty slow and may not be all that much faster than the eval itself, so getting the eval out of the TT loses most of the speedup.

That leads to this idea: avoid calculating the TT key and doing the TT key lookup until the last possible moment.

Prefetching can be done as a follow-up, but naming ```__builtin_prefetch``` is too many bytes.

```
ELO   | 3.85 +- 3.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 27648 W: 8043 L: 7737 D: 11868
```