### PR TITLE
Include promotions in Qsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,961 bytes
+3,975 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -319,6 +319,8 @@ void generate_piece_moves(Move *const movelist,
     if (!only_captures) {
         generate_pawn_moves(movelist, num_moves, north(pawns) & ~all, -8);
         generate_pawn_moves(movelist, num_moves, north(north(pawns & 0xFF00ULL) & ~all) & ~all, -16);
+    } else {
+         generate_pawn_moves(movelist, num_moves, north(pawns) & ~all & 0xFF000000000000FFULL, -8);
     }
     generate_pawn_moves(movelist, num_moves, nw(pawns) & (pos.colour[1] | pos.ep), -7);
     generate_pawn_moves(movelist, num_moves, ne(pawns) & (pos.colour[1] | pos.ep), -9);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -330,11 +330,10 @@ void generate_piece_moves(Move *const movelist,
 
 [[nodiscard]] auto movegen(const Position &pos, Move *const movelist, const bool only_captures) {
     int num_moves = 0;
-    const BB all = pos.colour[0] | pos.colour[1];
-    const BB to_mask = only_captures ? pos.colour[1] : ~pos.colour[0];
-    const BB pawns = pos.colour[0] & pos.pieces[Pawn];
-    generate_pawn_moves(
-        movelist, num_moves, north(pawns) & ~all & (only_captures ? 0xFF00000000000000ULL : ~0ULL), -8);
+    const u64 all = pos.colour[0] | pos.colour[1];
+    const u64 to_mask = only_captures ? pos.colour[1] : ~pos.colour[0];
+    const u64 pawns = pos.colour[0] & pos.pieces[Pawn];
+    generate_pawn_moves(movelist, num_moves, north(pawns) & ~all & (only_captures ? 0xFF00000000000000ULL : ~0ULL), -8);
     if (!only_captures) {
         generate_pawn_moves(movelist, num_moves, north(north(pawns & 0xFF00ULL) & ~all) & ~all, -16);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,7 +317,7 @@ void generate_piece_moves(Move *const movelist,
     const BB to_mask = only_captures ? pos.colour[1] : ~pos.colour[0];
     const BB pawns = pos.colour[0] & pos.pieces[Pawn];
     generate_pawn_moves(
-        movelist, num_moves, north(pawns) & ~all & (only_captures ? 0xFF000000000000FFULL : 0xFFFFFFFFFFFFFFFF), -8);
+        movelist, num_moves, north(pawns) & ~all & (only_captures ? 0xFF00000000000000ULL : 0xFFFFFFFFFFFFFFFF), -8);
     if (!only_captures) {
         generate_pawn_moves(movelist, num_moves, north(north(pawns & 0xFF00ULL) & ~all) & ~all, -16);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,11 +316,10 @@ void generate_piece_moves(Move *const movelist,
     const BB all = pos.colour[0] | pos.colour[1];
     const BB to_mask = only_captures ? pos.colour[1] : ~pos.colour[0];
     const BB pawns = pos.colour[0] & pos.pieces[Pawn];
+    generate_pawn_moves(
+        movelist, num_moves, north(pawns) & ~all & (only_captures ? 0xFF000000000000FFULL : 0xFFFFFFFFFFFFFFFF), -8);
     if (!only_captures) {
-        generate_pawn_moves(movelist, num_moves, north(pawns) & ~all, -8);
         generate_pawn_moves(movelist, num_moves, north(north(pawns & 0xFF00ULL) & ~all) & ~all, -16);
-    } else {
-         generate_pawn_moves(movelist, num_moves, north(pawns) & ~all & 0xFF000000000000FFULL, -8);
     }
     generate_pawn_moves(movelist, num_moves, nw(pawns) & (pos.colour[1] | pos.ep), -7);
     generate_pawn_moves(movelist, num_moves, ne(pawns) & (pos.colour[1] | pos.ep), -9);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,7 +317,7 @@ void generate_piece_moves(Move *const movelist,
     const BB to_mask = only_captures ? pos.colour[1] : ~pos.colour[0];
     const BB pawns = pos.colour[0] & pos.pieces[Pawn];
     generate_pawn_moves(
-        movelist, num_moves, north(pawns) & ~all & (only_captures ? 0xFF00000000000000ULL : 0xFFFFFFFFFFFFFFFF), -8);
+        movelist, num_moves, north(pawns) & ~all & (only_captures ? 0xFF00000000000000ULL : 0xFFFFFFFFFFFF0000ULL), -8);
     if (!only_captures) {
         generate_pawn_moves(movelist, num_moves, north(north(pawns & 0xFF00ULL) & ~all) & ~all, -16);
     }


### PR DESCRIPTION
```
ELO   | 5.97 +- 4.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12864 W: 3828 L: 3607 D: 5429
```
6/14