### PR TITLE
Introduce improving variable (take 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,912 bytes
+3,944 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,989 bytes
+4,019 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -555,7 +555,6 @@ def dissect(src: str, settings: Settings = Settings()) -> str:
 
         new.append(token)
 
-
         prev = token
 
     if "trailing_whitespace" in settings.filters:

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -421,6 +421,7 @@ def rename(tokens):
         "max_material":"m",
         "attacked_by_pawns":"dv",
         "pawn_attacked":"dw",
+        "improving":"dx",
         # Labels
         "do_search":"bk",
         "full_search":"bl",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -524,7 +524,7 @@ int alphabeta(Position &pos,
 
     // Check extensions
     depth = in_check ? max(1, depth + 1) : depth;
-    int improving = ply > 1 && static_eval > stack[ply - 2].score;
+    const int improving = ply > 1 && static_eval > stack[ply - 2].score;
     const int in_qsearch = depth <= 0;
 
     // TT probing

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,7 @@ struct [[nodiscard]] Stack {
     Move moves[218];
     Move move;
     Move killer;
+    int score;
 };
 
 struct [[nodiscard]] TT_Entry {
@@ -515,7 +516,7 @@ int alphabeta(Position &pos,
               const int do_null = true) {
     const auto in_check = attacked(pos, lsb(pos.colour[0] & pos.pieces[King]));
     const int static_eval = eval(pos);
-
+    stack[ply].score = static_eval;
     // Don't overflow the stack
     if (ply > 127) {
         return static_eval;
@@ -523,7 +524,7 @@ int alphabeta(Position &pos,
 
     // Check extensions
     depth = in_check ? max(1, depth + 1) : depth;
-
+    int improving = ply > 1 && static_eval > stack[ply - 2].score;
     const int in_qsearch = depth <= 0;
 
     // TT probing
@@ -549,8 +550,8 @@ int alphabeta(Position &pos,
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
             if (depth < 5) {
-                const int margins[] = {0, 50, 100, 200, 300};
-                if (static_eval - margins[depth] >= beta) {
+                const int margins[] = {50, 50, 100, 200, 300};
+                if (static_eval - margins[depth-improving] >= beta) {
                     return beta;
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -695,8 +695,10 @@ int alphabeta(Position &pos,
                                hash_history);
         } else {
             // Late move reduction
-            int reduction =
-                depth > 3 && moves_evaluated > 3 ? 1 + moves_evaluated / 16 + depth / 10 + (alpha == beta - 1) : 0;
+            int reduction = max(0,
+                                depth > 3 && moves_evaluated > 3
+                                    ? 1 + moves_evaluated / 16 + depth / 10 + (alpha == beta - 1) - improving
+                                    : 0);
 
         zero_window:
             score = -alphabeta(npos,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -516,12 +516,11 @@ int alphabeta(Position &pos,
               const int do_null = true) {
     const auto in_check = attacked(pos, lsb(pos.colour[0] & pos.pieces[King]));
     const int static_eval = eval(pos);
-    stack[ply].score = static_eval;
     // Don't overflow the stack
     if (ply > 127) {
         return static_eval;
     }
-
+    stack[ply].score = static_eval;
     // Check extensions
     depth = in_check ? max(1, depth + 1) : depth;
     const int improving = ply > 1 && static_eval > stack[ply - 2].score;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -550,7 +550,7 @@ int alphabeta(Position &pos,
             // Reverse futility pruning
             if (depth < 5) {
                 const int margins[] = {50, 50, 100, 200, 300};
-                if (static_eval - margins[depth-improving] >= beta) {
+                if (static_eval - margins[depth - improving] >= beta) {
                     return beta;
                 }
             }


### PR DESCRIPTION
slightly different version of the previous pr that has better elo yield while having a worse size ratio (we also get a more recent test as an added bonus)
```
ELO   | 9.21 +- 6.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6904 W: 2018 L: 1835 D: 3051
```