### PR TITLE
Ho ho ho it's tournament time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,989 bytes
+4,096 bytes
 ```
 
 ---

--- a/minifier/minify.py
+++ b/minifier/minify.py
@@ -423,6 +423,8 @@ def rename(tokens):
         "pawn_attacked":"dw",
         "no_move":"dx",
         "reduction":"dy",
+        "quiet_moves_evaluated":"dz",
+        "improving":"ea",
         # Labels
         "do_search":"bk",
         "full_window":"bl",


### PR DESCRIPTION
To make it easier to make the tournament deadline,
get a submission-ready branch set up.

Merges most of the outstanding strength patches:

* Bad bishop eval (#56).
* Late move pruning changes (#78).
* Improving variable (#83).
* Include promotions in qsearch (#97).

Also include #95 to make this exactly 4096 bytes,
and put in tournament settings (hash/threads) that keep the size at exactly that.

vs master (432c06a):

ELO   | 18.58 +- 9.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3032 W: 945 L: 783 D: 1304