### PR TITLE
No late move reduction for captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,928 bytes
+3,934 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -712,8 +712,9 @@ int alphabeta(Position &pos,
                                hash_history);
         } else {
             // Late move reduction
-            int reduction =
-                depth > 3 && moves_evaluated > 3 && piece_on(pos, move.to) == None? 1 + moves_evaluated / 16 + depth / 10 + (alpha == beta - 1) : 0;
+            int reduction = depth > 3 && moves_evaluated > 3 && piece_on(pos, move.to) == None
+                                ? 1 + moves_evaluated / 16 + depth / 10 + (alpha == beta - 1)
+                                : 0;
 
         zero_window:
             score = -alphabeta(npos,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -696,7 +696,7 @@ int alphabeta(Position &pos,
         } else {
             // Late move reduction
             int reduction =
-                depth > 3 && moves_evaluated > 3 ? 1 + moves_evaluated / 16 + depth / 10 + (alpha == beta - 1) : 0;
+                depth > 3 && moves_evaluated > 3 && piece_on(pos, move.to) == None? 1 + moves_evaluated / 16 + depth / 10 + (alpha == beta - 1) : 0;
 
         zero_window:
             score = -alphabeta(npos,


### PR DESCRIPTION
```
ELO   | 3.33 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 37432 W: 10600 L: 10241 D: 16591
```

http://chess.grantnet.us/test/30020/

+6 bytes