### PR TITLE
Handle inverted wtime btime order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Removed:
 - The first line of input after startup will be interpreted as `uci` even if it isn't.
 - `stop` is unsupported.
 - `position fen [fen] moves [moves]` is not supported. `position startpos moves [moves]` must be used instead.
-- `go` only supports `wtime` and `btime`.
+- `go` only supports `wtime` and `btime`, in that order.
 - `setoption` is not supported. Relevant variables are hard coded.
 
 4ku has additional support for:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1072,6 +1072,12 @@ int main(
             int wtime;
             int btime;
             cin >> word >> wtime >> word >> btime;
+            // minify enable filter delete
+            if (word == "wtime") {
+                swap(wtime, btime);
+            }
+            // minify disable filter delete
+
             const auto start = now();
             const auto allocated_time = (pos.flipped ? btime : wtime) / 3;
 


### PR DESCRIPTION
Although the majority of UCI interfaces do the sensible thing and just send ```wtime btime``` in that order, for whatever reason ChessBase programs can start to send them in inverted order in the middle of a game. Detect and handle this.

Not required for the 4k tournament as the command format is defined in the rules.

No size impact.