### PR TITLE
Promotions in qsearch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,943 bytes
+3,949 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -333,8 +333,9 @@ void generate_piece_moves(Move *const movelist,
     const u64 all = pos.colour[0] | pos.colour[1];
     const u64 to_mask = only_captures ? pos.colour[1] : ~pos.colour[0];
     const u64 pawns = pos.colour[0] & pos.pieces[Pawn];
+    generate_pawn_moves(
+        movelist, num_moves, north(pawns) & ~all & (only_captures ? 0xFF00000000000000ULL : ~0ULL), -8);
     if (!only_captures) {
-        generate_pawn_moves(movelist, num_moves, north(pawns) & ~all, -8);
         generate_pawn_moves(movelist, num_moves, north(north(pawns & 0xFF00ULL) & ~all) & ~all, -16);
     }
     generate_pawn_moves(movelist, num_moves, nw(pawns) & (pos.colour[1] | pos.ep), -7);


### PR DESCRIPTION
Rebase of #97 by PGG106, with constants tweaked to please the current minfier and get it down to 6 bytes.

Score of 4ku vs master: 3413 - 3215 - 6226  [0.508] 12854
...      4ku playing White: 1855 - 1388 - 3185  [0.536] 6428
...      4ku playing Black: 1558 - 1827 - 3041  [0.479] 6426
...      White vs Black: 3682 - 2946 - 6226  [0.529] 12854
Elo difference: 5.4 +/- 4.3, LOS: 99.2 %, DrawRatio: 48.4 %
SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted