### PR TITLE
No NMP if only pawns left

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,971 bytes
+3,980 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -573,7 +573,7 @@ int alphabeta(Position &pos,
             }
 
             // Null move pruning
-            if (depth > 2 && static_eval >= beta && do_null) {
+            if (depth > 2 && static_eval >= beta && do_null && pos.colour[0] & ~(pos.pieces[Pawn] | pos.pieces[King])) {
                 auto npos = pos;
                 flip(npos);
                 npos.ep = 0;


### PR DESCRIPTION
```
ELO   | 4.93 +- 3.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 17136 W: 4898 L: 4655 D: 7583
```

http://chess.grantnet.us/test/30160/

+7 bytes