### PR TITLE
MVV instead of MVVLVA

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,981 bytes
+3,974 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -634,7 +634,7 @@ int alphabeta(Position &pos,
         if (moves[j] == tt_move) {
             move_scores[j] = 1LL << 62;
         } else if (capture != None) {
-            move_scores[j] = ((capture + 1) * (1LL << 54)) - piece_on(pos, moves[j].from);
+            move_scores[j] = (capture + 1) * (1LL << 54);
         } else if (moves[j] == stack[ply].killer) {
             move_scores[j] = 1LL << 50;
         } else {


### PR DESCRIPTION
```
ELO   | -2.09 +- 4.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | -2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12328 W: 3416 L: 3490 D: 5422
```

http://chess.grantnet.us/test/30207/

-7 bytes

Might be worth merging if we run out of space