### PR TITLE
LMR adjustments on history heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,026 bytes
+4,032 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -705,7 +705,8 @@ int alphabeta(Position &pos,
         } else {
             // Late move reduction
             int reduction = depth > 1 && num_moves_evaluated > 5 && piece_on(pos, move.to) == None
-                                ? 1 + num_moves_evaluated / 16 + depth / 8 + (alpha == beta - 1) - improving
+                                ? 1 + num_moves_evaluated / 16 + depth / 8 + (alpha == beta - 1) - improving +
+                                      (hh_table[pos.flipped][move.from][move.to] < 0)
                                 : 0;
 
         zero_window:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -705,8 +705,8 @@ int alphabeta(Position &pos,
         } else {
             // Late move reduction
             int reduction = depth > 1 && num_moves_evaluated > 5 && piece_on(pos, move.to) == None
-                                ? 1 + num_moves_evaluated / 16 + depth / 8 + (alpha == beta - 1) - improving -
-                                      (hh_table[pos.flipped][move.from][move.to] > 0)
+                                ? 1 + num_moves_evaluated / 16 + depth / 8 + (alpha == beta - 1) - improving +
+                                      (hh_table[pos.flipped][move.from][move.to] < 0)
                                 : 0;
 
         zero_window:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -705,8 +705,8 @@ int alphabeta(Position &pos,
         } else {
             // Late move reduction
             int reduction = depth > 1 && num_moves_evaluated > 5 && piece_on(pos, move.to) == None
-                                ? 1 + num_moves_evaluated / 16 + depth / 8 + (alpha == beta - 1) - improving +
-                                      (hh_table[pos.flipped][move.from][move.to] < 0)
+                                ? 1 + num_moves_evaluated / 16 + depth / 8 + (alpha == beta - 1) - improving -
+                                      (hh_table[pos.flipped][move.from][move.to] > 0)
                                 : 0;
 
         zero_window:


### PR DESCRIPTION
```
ELO   | 10.95 +- 6.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5552 W: 1651 L: 1476 D: 2425
```

http://chess.grantnet.us/test/30347/

+6 bytes