### PR TITLE
Speedup hash calculation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,039 bytes
+4,049 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -499,11 +499,19 @@ const int pawn_attacked[] = {S(-64, -14), S(-55, -42)};
     u64 hash = pos.flipped;
 
     // Pieces
-    u64 copy = pos.colour[0] | pos.colour[1];
-    while (copy) {
-        const int sq = lsb(copy);
-        copy &= copy - 1;
-        hash ^= keys[(piece_on(pos, sq) + 6 * ((pos.colour[pos.flipped] >> sq) & 1)) * 64 + sq];
+    for (int p = Pawn; p < None; p++) {
+        u64 copy = pos.pieces[p] & pos.colour[0];
+        while (copy) {
+            const int sq = lsb(copy);
+            copy &= copy - 1;
+            hash ^= keys[p * 64 + sq];
+        }
+        copy = pos.pieces[p] & pos.colour[1];
+        while (copy) {
+            const int sq = lsb(copy);
+            copy &= copy - 1;
+            hash ^= keys[(p + 6) * 64 + sq];
+        }
     }
 
     // En passant square


### PR DESCRIPTION
About 2.5x faster.

```
ELO   | 17.56 +- 8.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3248 W: 997 L: 833 D: 1418
```