### PR TITLE
Delay move sorting after hash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,047 bytes
+4,066 bytes
 ```
 
 ---


### PR DESCRIPTION
```
ELO   | 8.73 +- 5.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7408 W: 2187 L: 2001 D: 3220
```

At +32 bytes this is meh, but there may be possibilities to trim this down.