### PR TITLE
Update TT with lower depth if bound is better.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,066 bytes
+4,069 bytes
 ```
 
 ---


### PR DESCRIPTION
Because http://chess.grantnet.us/test/30475/ failed, there is some indication that overwriting higher depth entries with lower depth ones is useful if the lower depth ones have a better bound quality.

Extend this idea to fail high vs fail low entries, where we may add a best move.

```
ELO   | 5.92 +- 4.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12848 W: 3779 L: 3560 D: 5509
```