### PR TITLE
Move generation using reverse bitboards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,866 bytes
+3,947 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,18 +201,25 @@ template <typename F>
     return mask;
 }
 
-[[nodiscard]] u64 knight(const i32 sq, const u64) {
-    const u64 bb = 1ULL << sq;
-    return (bb << 15 | bb >> 17) & 0x7F7F7F7F7F7F7F7FULL | (bb << 17 | bb >> 15) & 0xFEFEFEFEFEFEFEFEULL |
-           (bb << 10 | bb >> 6) & 0xFCFCFCFCFCFCFCFCULL | (bb << 6 | bb >> 10) & 0x3F3F3F3F3F3F3F3FULL;
+u64 diag_mask[64];
+
+[[nodiscard]] u64 xattack(const i32 sq, const u64 blockers, const u64 dir_mask) {
+    return dir_mask & ((blockers & dir_mask) - (1ULL << sq) ^ flip(flip(blockers & dir_mask) - flip(1ULL << sq)));
 }
 
 [[nodiscard]] u64 bishop(const i32 sq, const u64 blockers) {
-    return ray(sq, blockers, nw) | ray(sq, blockers, ne) | ray(sq, blockers, sw) | ray(sq, blockers, se);
+    return xattack(sq, blockers, diag_mask[sq]) | xattack(sq, blockers, flip(diag_mask[sq ^ 56]));
 }
 
 [[nodiscard]] u64 rook(const i32 sq, const u64 blockers) {
-    return ray(sq, blockers, north) | ray(sq, blockers, east) | ray(sq, blockers, south) | ray(sq, blockers, west);
+    return xattack(sq, blockers, (1ULL << sq) ^ (0x101010101010101ULL << (sq % 8))) | ray(sq, blockers, east) |
+           ray(sq, blockers, west);
+}
+
+[[nodiscard]] u64 knight(const i32 sq, const u64) {
+    const u64 bb = 1ULL << sq;
+    return (((bb << 15) | (bb >> 17)) & 0x7F7F7F7F7F7F7F7FULL) | (((bb << 17) | (bb >> 15)) & 0xFEFEFEFEFEFEFEFEULL) |
+           (((bb << 10) | (bb >> 6)) & 0xFCFCFCFCFCFCFCFCULL) | (((bb << 6) | (bb >> 10)) & 0x3F3F3F3F3F3F3F3FULL);
 }
 
 [[nodiscard]] u64 king(const i32 sq, const u64) {
@@ -982,6 +989,10 @@ i32 main(
 ) {
     setbuf(stdout, 0);
 
+    // Generate used attack masks
+    for (i32 i = 0; i < 64; ++i) {
+        diag_mask[i] = ray(i, 0, ne) | ray(i, 0, sw);
+    }
     mt19937_64 r;
     // pieces from 1-12 multiplied by the square + ep squares + castling rights
     for (u64 &k : keys)


### PR DESCRIPTION
Speed up attack and move generation by calculating everything but rank attacks with reverse bitboards, Hyperbola Quintessence variation.

```
ELO   | 23.63 +- 10.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2312 W: 738 L: 581 D: 993
```

~24 Elo for 85 bytes