### PR TITLE
Poor man's SEE pruning in qsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,956 bytes
+3,978 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -684,6 +684,14 @@ int alphabeta(Position &pos,
             break;
         }
 
+        // Poor man's SEE pruning
+        if (in_qsearch && !in_check &&
+            max_material[piece_on(pos, move.to)] - max_material[piece_on(pos, move.from)] < -150 &&
+            attacked(pos, move.to)) {
+            best_score = alpha;
+            continue;
+        }
+
         auto npos = pos;
         if (!makemove(npos, move)) {
             continue;


### PR DESCRIPTION
STC:
```
ELO   | 2.81 +- 1.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 73328 W: 22457 L: 21865 D: 29006
```
http://chess.grantnet.us/test/31452/
+20 bytes

---
Old results:
STC:
```
ELO   | 11.92 +- 7.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5104 W: 1562 L: 1387 D: 2155
```
http://chess.grantnet.us/test/30746/

+22 bytes