### PR TITLE
Use null windows in the qsearch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,956 bytes
+3,953 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -694,7 +694,7 @@ int alphabeta(Position &pos,
         // minify disable filter delete
 
         int score;
-        if (in_qsearch || !num_moves_evaluated) {
+        if (!num_moves_evaluated) {
         full_window:
             score = -alphabeta(npos,
                                -beta,


### PR DESCRIPTION
Reduces size, simpler code.

```
ELO   | -0.06 +- 2.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 42888 W: 12266 L: 12273 D: 18349
```