### PR TITLE
Fix kingsafety masks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,008 bytes
+4,003 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -351,20 +351,20 @@ const int phases[] = {0, 1, 1, 2, 4, 0};
 const int max_material[] = {116, 352, 378, 662, 1227, 0, 0};
 const int material[] = {S(116, 109), S(352, 348), S(378, 365), S(472, 662), S(967, 1227), 0};
 const int pst_rank[][8] = {
-    {0, S(-9, 4), S(-10, 2), S(-6, 2), S(-2, 3), S(6, 4), S(3, -4), 0},
+    {0, S(-10, 4), S(-11, 2), S(-6, 2), S(-2, 3), S(6, 4), S(3, -4), 0},
     {S(-12, -5), S(-6, 0), S(-1, 4), S(4, 8), S(12, 9), S(20, 5), S(11, 2), S(-10, -1)},
     {S(-10, -3), S(-3, 1), S(1, 3), S(3, 5), S(5, 6), S(14, 2), S(4, 3), S(-13, 2)},
     {S(-1, -9), S(-4, -11), S(-5, -9), S(-5, -5), S(1, -2), S(9, -2), S(12, -1), S(5, 0)},
     {S(-8, -20), S(-4, -17), S(-4, -10), S(-6, 1), S(-2, 6), S(6, 3), S(-7, 11), S(-1, 3)},
-    {S(-1, -8), S(5, -2), S(-9, 2), S(-11, 5), S(-10, 8), S(-2, 8), S(15, 3), S(-6, -1)},
+    {S(1, -6), S(-2, 2), S(-6, 4), S(-13, 8), S(-6, 10), S(7, 9), S(11, 7), S(11, -1)},
 };
 const int pst_file[][4] = {{S(2, -5), S(9, -5), S(6, -5), S(7, -7)},
                            {S(-10, -9), S(-4, -5), S(2, -1), S(3, 1)},
                            {S(-4, -5), S(2, -3), S(1, -1), S(2, 0)},
                            {S(-3, 0), S(-2, 1), S(-1, 2), S(0, 1)},
                            {S(-9, 0), S(-6, 1), S(-4, 5), S(-3, 5)},
-                           {S(-1, -3), S(1, 1), S(-10, 4), S(1, 1)}};
-const int pawn_protection[] = {S(20, 15), S(9, 12), S(2, 5), S(4, 7), S(-6, 19), S(-48, 27)};
+                           {S(4, -11), S(7, -7), S(-3, -4), S(-10, -3)}};
+const int pawn_protection[] = {S(20, 15), S(9, 12), S(2, 5), S(4, 7), S(-6, 19), S(-41, 23)};
 const int passers[] = {S(-31, 17), S(-19, 8), S(3, 20), S(19, 52), S(48, 119), S(132, 209)};
 const int pawn_doubled = S(-29, -25);
 const int pawn_passed_blocked[] = {S(16, -16), S(-35, -4), S(-55, -11), S(5, -35), S(6, -65), S(28, -75)};
@@ -372,7 +372,7 @@ const int pawn_passed_king_distance[] = {S(3, -6), S(-6, 9)};
 const int bishop_pair = S(27, 68);
 const int rook_open = S(61, 7);
 const int rook_semi_open = S(27, 20);
-const int king_shield[] = {S(40, -5), S(26, -7), S(-85, 18)};
+const int king_shield[] = {S(52, -9), S(40, -10), S(-19, 2)};
 const int pawn_attacked[] = {S(-64, -14), S(-155, -142)};
 
 [[nodiscard]] int eval(Position &pos) {
@@ -458,13 +458,16 @@ const int pawn_attacked[] = {S(-64, -14), S(-155, -142)};
                                 score += rook_semi_open;
                             }
                         }
-                    } else if (p == King && piece_bb & 0xE7) {
+                    } else if (p == King && piece_bb & 0xC3D7) {
+                        // C3D7 = Reasonable king squares
+                        // Pawn cover is fixed in position, so it won't
+                        // walk around with the king.
                         const u64 shield = file < 3 ? 0x700 : 0xE000;
                         score += count(shield & pawns[0]) * king_shield[0];
                         score += count(north(shield) & pawns[0]) * king_shield[1];
 
-                        // C3D7 = Reasonable king squares
-                        score += !(piece_bb & 0xC3D7) * king_shield[2];
+                        // Bonus for being castled or still being able to.
+                        score += king_shield[2];
                     }
                 }
             }


### PR DESCRIPTION
The bonus for a reasonable square never worked correctly because we missed that the whole king branch already applies a king position mask.

-5 bytes

ELO   | 5.58 +- 5.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 9968 W: 3096 L: 2936 D: 3936