### PR TITLE
Don't prune promotions and order them properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,004 bytes
+3,999 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,003 bytes
+4,004 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -636,8 +636,8 @@ int alphabeta(Position &pos,
         // then we'll use that first and delay sorting one iteration.
         if (i == !(no_move == tt_move)) {
             for (int j = 0; j < num_moves; ++j) {
-                const auto gain = moves[j].promo != None ? moves[j].promo : piece_on(pos, moves[j].to);
-                if (gain != None) {
+                const auto gain = max_material[moves[j].promo] + max_material[piece_on(pos, moves[j].to)];
+                if (gain) {
                     move_scores[j] = gain + (1LL << 54);
                 } else if (moves[j] == stack[ply].killer) {
                     move_scores[j] = 1LL << 50;
@@ -669,7 +669,7 @@ int alphabeta(Position &pos,
         move_scores[best_move_index] = move_scores[i];
 
         // Material gain
-        const auto gain = max_material[move.promo != None ? move.promo : piece_on(pos, move.to)];
+        const auto gain = max_material[move.promo] + max_material[piece_on(pos, move.to)];
 
         // Delta pruning
         if (in_qsearch && !in_check && static_eval + 50 + gain < alpha) {


### PR DESCRIPTION
+1 byte

```
ELO   | 7.23 +- 5.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9752 W: 2921 L: 2718 D: 4113
```

I observed that 4ku needs more than a 1 ply search or qsearch to find the correct move in the following position: 8/R7/4kP1p/8/8/4K3/6pN/8 b - - 0 1
Which itself was found by looking for very large
qsearch vs deep search inconsistencies.

The underlying cause is that KxP is not pruned,
but promoting to a queen is. That's unfortunate,
and fixing it seems to help.