### PR TITLE
Remove a kingsafety bonus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sh build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,987 bytes
+3,982 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -348,19 +348,19 @@ const int phases[] = {0, 1, 1, 2, 4, 0};
 const int max_material[] = {116, 352, 378, 662, 1227, 0, 0};
 const int material[] = {S(116, 109), S(352, 348), S(378, 365), S(472, 662), S(967, 1227), 0};
 const int pst_rank[][8] = {
-    {0, S(-10, 4), S(-11, 2), S(-6, 2), S(-2, 3), S(6, 4), S(3, -4), 0},
+    {0, S(-11, 5), S(-12, 3), S(-7, 3), S(-3, 4), S(6, 4), S(6, -9), 0},
     {S(-12, -5), S(-6, 0), S(-1, 4), S(4, 8), S(12, 9), S(20, 5), S(11, 2), S(-10, -1)},
     {S(-10, -3), S(-3, 1), S(1, 3), S(3, 5), S(5, 6), S(14, 2), S(4, 3), S(-13, 2)},
     {S(-1, -9), S(-4, -11), S(-5, -9), S(-5, -5), S(1, -2), S(9, -2), S(12, -1), S(5, 0)},
     {S(-8, -20), S(-4, -17), S(-4, -10), S(-6, 1), S(-2, 6), S(6, 3), S(-7, 11), S(-1, 3)},
-    {S(1, -6), S(-2, 2), S(-6, 4), S(-13, 8), S(-6, 10), S(7, 9), S(11, 7), S(11, -1)},
+    {S(-3, -4), S(-4, 3), S(-6, 5), S(-15, 9), S(-8, 11), S(9, 10), S(11, 7), S(14, -2)},
 };
-const int pst_file[][4] = {{S(2, -5), S(9, -5), S(6, -5), S(7, -7)},
+const int pst_file[][4] = {{S(3, -6), S(10, -6), S(7, -6), S(9, -8)},
                            {S(-10, -9), S(-4, -5), S(2, -1), S(3, 1)},
                            {S(-4, -5), S(2, -3), S(1, -1), S(2, 0)},
                            {S(-3, 0), S(-2, 1), S(-1, 2), S(0, 1)},
                            {S(-9, 0), S(-6, 1), S(-4, 5), S(-3, 5)},
-                           {S(4, -11), S(7, -7), S(-3, -4), S(-10, -3)}};
+                           {S(3, -10), S(7, -6), S(-2, -3), S(-9, -2)}};
 const int pawn_protection[] = {S(20, 15), S(9, 12), S(2, 5), S(4, 7), S(-6, 19), S(-41, 23)};
 const int passers[] = {S(-31, 17), S(-19, 8), S(3, 20), S(19, 52), S(48, 119), S(132, 209)};
 const int pawn_doubled = S(-29, -25);
@@ -369,7 +369,7 @@ const int pawn_passed_king_distance[] = {S(3, -6), S(-6, 9)};
 const int bishop_pair = S(27, 68);
 const int rook_open = S(61, 7);
 const int rook_semi_open = S(27, 20);
-const int king_shield[] = {S(52, -9), S(40, -10), S(-19, 2)};
+const int king_shield[] = {S(50, -9), S(38, -10)};
 const int pawn_attacked[] = {S(-64, -14), S(-155, -142)};
 
 [[nodiscard]] int eval(Position &pos) {
@@ -462,9 +462,6 @@ const int pawn_attacked[] = {S(-64, -14), S(-155, -142)};
                         const u64 shield = file < 3 ? 0x700 : 0xE000;
                         score += count(shield & pawns[0]) * king_shield[0];
                         score += count(north(shield) & pawns[0]) * king_shield[1];
-
-                        // Bonus for being castled or still being able to.
-                        score += king_shield[2];
                     }
                 }
             }


### PR DESCRIPTION
@GediminasMasaitis pointed out that the third kingsafety bonus is actually negative, so at best it serves as normalizing constant.

We can probably just simplify it away. The PST will cover the difference between being castled and being able to castle anyway.

Note this "failed" at -1.6 Elo, but we should take it anyway:

- It's ``-5`` bytes so the Elo/byte for removing is good.
- It makes no sense.
- Removing E1 from the mask so it becomes a pure castling bonus leads to a negligible eval term (S(-4, 0) note again it's negative!), which reinforces this doesn't really do anything sensible.

STC

```
ELO   | -1.62 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | -2.96 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 78752 W: 22548 L: 22915 D: 33289
```