### PR TITLE
Endgame scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,001 bytes
+4,011 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -479,8 +479,10 @@ const int pawn_attacked[] = {S(-64, -14), S(-155, -142)};
         score = -score;
     }
 
-    // Tapered eval
-    return ((short)score * phase + ((score + 0x8000) >> 16) * (24 - phase)) / 24;
+    // Tapered eval with endgame scaling based on remaining pawn count of the stronger side
+    return ((short)score * phase +
+            (score + 0x8000 >> 16) * (16 + count(pos.colour[score < 0] & pos.pieces[Pawn])) / 24 * (24 - phase)) /
+           24;
 }
 
 [[nodiscard]] auto get_hash(const Position &pos) {


### PR DESCRIPTION
STC:
```
ELO   | 9.65 +- 6.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6592 W: 1995 L: 1812 D: 2785
```
http://chess.grantnet.us/test/31552/

LTC:
```
ELO   | 7.73 +- 5.39 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8496 W: 2359 L: 2170 D: 3967
```
http://chess.grantnet.us/test/31553/

+10 bytes