### PR TITLE
Loosen RFP margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,011 bytes
+4,013 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -564,7 +564,7 @@ int alphabeta(Position &pos,
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
             if (depth < 7) {
-                const int margins[] = {0, 50, 100, 200, 300, 500, 800};
+                const int margins[] = {0, 70, 150, 250, 400, 600, 900};
                 if (static_eval - margins[depth - improving] >= beta) {
                     return beta;
                 }


### PR DESCRIPTION
seems to be lots of tuning potential for search params
+2 bytes

10+0.1:
```
Score of 4ku-less-rfp vs 4ku after 2714 games: 609 - 505 - 1594 (0.52)
Ptnml:        WW     WD  DD/WL     LD     LL
Distr:        57    367    585    311     33
LLR: 2.97 (-2.94, 2.94) [0.00, 5.00]
Stats:  W: 22.4%   L: 18.6%   D: 58.7%   TF: 0
Elo difference: 13.35 +/- 8.38
```

w/ pentanomial results:

```
Estimates
=========
Elo                         :  12.52
Confidence interval         :  [3.92,21.12] (95.00%)
LOS                         :  99.78%
```