### PR TITLE
slight parameter changes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -571,7 +571,7 @@ int alphabeta(Position &pos,
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
             if (depth < 7) {
-                const int margins[] = {0, 50, 100, 200, 300, 500, 800};
+                const int margins[] = {0, 70, 140, 210, 280, 400, 550};
                 if (static_eval - margins[depth - improving] >= beta) {
                     return beta;
                 }
@@ -585,8 +585,9 @@ int alphabeta(Position &pos,
                 if (-alphabeta(npos,
                                -beta,
                                -beta + 1,
-                               depth - 4 - depth / 6,
-                               ply + 1,
+                               depth - 3 - depth / 6 - std::min((static_eval - beta)/200, 3),
+                               //increment ply by two to get refutation for killer tables if it fails
+                               ply + 2, 
                                // minify enable filter delete
                                nodes,
                                // minify disable filter delete
@@ -615,7 +616,7 @@ int alphabeta(Position &pos,
         }
     }
     // Internal iterative reduction
-    else if (depth > 3) {
+    else if (depth > 3 && alpha != beta-1) {
         depth--;
     }
 


### PR DESCRIPTION
- IIR used only in PV-nodes
- NMP depth reduction change to use static eval
- ply count for NMP now +2, this is so that when a quiet move refutes null move it can be searched early as refutations for other moves too