### PR TITLE
Static eval in NMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,953 bytes
+3,971 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -585,7 +585,7 @@ int alphabeta(Position &pos,
                 if (-alphabeta(npos,
                                -beta,
                                -beta + 1,
-                               depth - 4 - depth / 6,
+                               depth - 3 - depth / 6 - min((eval - beta) / 200, 3),
                                // increment ply by two to get refutation for killer tables if it fails
                                ply + 2, 
                                // minify enable filter delete
@@ -616,7 +616,7 @@ int alphabeta(Position &pos,
         }
     }
     // Internal iterative reduction
-    else if (depth > 3 && alpha != beta-1) {
+    else if (depth > 3) {
         depth--;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -571,7 +571,7 @@ int alphabeta(Position &pos,
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
             if (depth < 7) {
-                const int margins[] = {0, 70, 140, 210, 280, 400, 550};
+                const int margins[] = {0, 50, 100, 200, 300, 500, 800};
                 if (static_eval - margins[depth - improving] >= beta) {
                     return beta;
                 }
@@ -585,7 +585,7 @@ int alphabeta(Position &pos,
                 if (-alphabeta(npos,
                                -beta,
                                -beta + 1,
-                               depth - 3 - depth / 6 - min((static_eval - beta) / 200, 3),
+                               depth - 4 - depth / 6,
                                // increment ply by two to get refutation for killer tables if it fails
                                ply + 2, 
                                // minify enable filter delete

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -571,7 +571,7 @@ int alphabeta(Position &pos,
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
             if (depth < 7) {
-                const int margins[] = {0, 50, 100, 200, 300, 500, 800};
+                const int margins[] = {0, 70, 140, 210, 280, 400, 550};
                 if (static_eval - margins[depth - improving] >= beta) {
                     return beta;
                 }
@@ -585,8 +585,9 @@ int alphabeta(Position &pos,
                 if (-alphabeta(npos,
                                -beta,
                                -beta + 1,
-                               depth - 4 - depth / 6,
-                               ply + 1,
+                               depth - 3 - depth / 6 - std::min((static_eval - beta)/200, 3),
+                               //increment ply by two to get refutation for killer tables if it fails
+                               ply + 2, 
                                // minify enable filter delete
                                nodes,
                                // minify disable filter delete
@@ -615,7 +616,7 @@ int alphabeta(Position &pos,
         }
     }
     // Internal iterative reduction
-    else if (depth > 3) {
+    else if (depth > 3 && alpha != beta-1) {
         depth--;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -587,7 +587,7 @@ int alphabeta(Position &pos,
                                -beta + 1,
                                depth - 4 - depth / 6 - min((static_eval - beta) / 200, 3),
                                // increment ply by two to get refutation for killer tables if it fails
-                               ply + 2, 
+                               ply + 1, 
                                // minify enable filter delete
                                nodes,
                                // minify disable filter delete

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -585,7 +585,7 @@ int alphabeta(Position &pos,
                 if (-alphabeta(npos,
                                -beta,
                                -beta + 1,
-                               depth - 3 - depth / 6 - min((static_eval - beta) / 200, 3),
+                               depth - 4 - depth / 6 - min((static_eval - beta) / 200, 3),
                                // increment ply by two to get refutation for killer tables if it fails
                                ply + 2, 
                                // minify enable filter delete

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -585,8 +585,8 @@ int alphabeta(Position &pos,
                 if (-alphabeta(npos,
                                -beta,
                                -beta + 1,
-                               depth - 3 - depth / 6 - std::min((static_eval - beta)/200, 3),
-                               //increment ply by two to get refutation for killer tables if it fails
+                               depth - 3 - depth / 6 - min((static_eval - beta) / 200, 3),
+                               // increment ply by two to get refutation for killer tables if it fails
                                ply + 2, 
                                // minify enable filter delete
                                nodes,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -585,7 +585,7 @@ int alphabeta(Position &pos,
                 if (-alphabeta(npos,
                                -beta,
                                -beta + 1,
-                               depth - 3 - depth / 6 - min((eval - beta) / 200, 3),
+                               depth - 3 - depth / 6 - min((static_eval - beta) / 200, 3),
                                // increment ply by two to get refutation for killer tables if it fails
                                ply + 2, 
                                // minify enable filter delete

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -586,7 +586,6 @@ int alphabeta(Position &pos,
                                -beta,
                                -beta + 1,
                                depth - 4 - depth / 6 - min((static_eval - beta) / 200, 3),
-                               // increment ply by two to get refutation for killer tables if it fails
                                ply + 1, 
                                // minify enable filter delete
                                nodes,


### PR DESCRIPTION
extra bytes: 18
openbench test: http://chess.grantnet.us/test/31820/

ELO   | 9.06 +- 6.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7096 W: 2142 L: 1957 D: 2997