### PR TITLE
Rework futility pruning conditions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,965 bytes
+3,969 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -678,7 +678,7 @@ int alphabeta(Position &pos,
         }
 
         // Forward futility pruning
-        if (depth < 8 && !in_qsearch && !in_check && !(move == tt_move) && static_eval + 150 * depth + gain < alpha) {
+        if (depth < 8 && !in_qsearch && !in_check && !(move == tt_move) && static_eval + 100 * depth + gain < alpha) {
             best_score = alpha;
             break;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -678,7 +678,7 @@ int alphabeta(Position &pos,
         }
 
         // Forward futility pruning
-        if (!in_qsearch && !in_check && !(move == tt_move) && static_eval + 150 * depth + gain < alpha) {
+        if (depth < 8 && !in_qsearch && !in_check && !(move == tt_move) && static_eval + 150 * depth + gain < alpha) {
             best_score = alpha;
             break;
         }


### PR DESCRIPTION
If alpha is a mate score, no move can possibly meet the threshold
and we fail low, even if there really is a mate. This means we can
be unable to find even mate in 1 with a deep search. A depth limit
seems like the simplest fix.

+4 bytes

Now that there is a depth condition, we can be more
aggressive with futility pruning.

```
STC

ELO   | 8.67 +- 5.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7536 W: 2252 L: 2064 D: 3220

LTC

ELO   | 3.37 +- 2.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 33192 W: 8768 L: 8446 D: 15978
```