### PR TITLE
Earlier TT

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,923 bytes
+3,929 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -548,7 +548,25 @@ int alphabeta(Position &pos,
         for (const auto old_hash : hash_history)
             if (old_hash == tt_key)
                 return 0;
+    }
 
+    // TT Probing
+    TT_Entry &tt_entry = transposition_table[tt_key % num_tt_entries];
+    Move tt_move{};
+    if (tt_entry.key == tt_key) {
+        tt_move = tt_entry.move;
+        if (ply > 0 && tt_entry.depth >= depth) {
+            if (tt_entry.flag == Upper && tt_entry.score <= alpha || tt_entry.flag == Lower && tt_entry.score >= beta ||
+                tt_entry.flag == Exact) {
+                return tt_entry.score;
+            }
+        }
+    }
+    // Internal iterative reduction
+    else if (depth > 3)
+        depth--;
+
+    if (ply > 0 && !in_qsearch) {
         if (!in_check && alpha == beta - 1) {
             // Reverse futility pruning
             if (depth < 7) {
@@ -580,22 +598,6 @@ int alphabeta(Position &pos,
             }
         }
     }
-
-    // TT Probing
-    TT_Entry &tt_entry = transposition_table[tt_key % num_tt_entries];
-    Move tt_move{};
-    if (tt_entry.key == tt_key) {
-        tt_move = tt_entry.move;
-        if (ply > 0 && tt_entry.depth >= depth) {
-            if (tt_entry.flag == Upper && tt_entry.score <= alpha || tt_entry.flag == Lower && tt_entry.score >= beta ||
-                tt_entry.flag == Exact) {
-                return tt_entry.score;
-            }
-        }
-    }
-    // Internal iterative reduction
-    else if (depth > 3)
-        depth--;
 
     hash_history.emplace_back(tt_key);
     uint16_t tt_flag = Upper;


### PR DESCRIPTION
STC:
```
ELO   | 6.04 +- 4.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12432 W: 3611 L: 3395 D: 5426
```
http://chess.grantnet.us/test/32114/

LTC:
```
ELO   | 10.11 +- 6.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5880 W: 1607 L: 1436 D: 2837
```
http://chess.grantnet.us/test/32117/

+6 bytes