### PR TITLE
Delay static evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,921 bytes
+3,918 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,929 bytes
+3,921 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -521,26 +521,15 @@ int alphabeta(Position &pos,
               int64_t (&hh_table)[2][64][64],
               vector<u64> &hash_history,
               const int do_null = true) {
-    const int static_eval = eval(pos);
-
     // Don't overflow the stack
     if (ply > 127)
-        return static_eval;
-
-    stack[ply].score = static_eval;
-    const auto improving = ply > 1 && static_eval > stack[ply - 2].score;
+        return eval(pos);
 
     // Check extensions
     const auto in_check = is_attacked(pos, lsb(pos.colour[0] & pos.pieces[King]));
     depth += in_check;
 
     const int in_qsearch = depth <= 0;
-    if (in_qsearch && static_eval > alpha) {
-        if (static_eval >= beta)
-            return beta;
-        alpha = static_eval;
-    }
-
     const u64 tt_key = get_hash(pos);
 
     if (ply > 0 && !in_qsearch) {
@@ -565,6 +554,16 @@ int alphabeta(Position &pos,
     // Internal iterative reduction
     else if (depth > 3)
         depth--;
+
+    const int static_eval = eval(pos);
+    stack[ply].score = static_eval;
+    const auto improving = ply > 1 && static_eval > stack[ply - 2].score;
+
+    if (in_qsearch && static_eval > alpha) {
+        if (static_eval >= beta)
+            return beta;
+        alpha = static_eval;
+    }
 
     if (ply > 0 && !in_qsearch) {
         if (!in_check && alpha == beta - 1) {


### PR DESCRIPTION
STC:
```
ELO   | 0.53 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | -3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 33720 W: 9467 L: 9416 D: 14837
```
http://chess.grantnet.us/test/32124/

LTC:
```
ELO   | 2.38 +- 4.12 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 13888 W: 3582 L: 3487 D: 6819
```
http://chess.grantnet.us/test/32129/

-5 bytes

The STC and LTC can't be compared directly because STC was a gainer test and LTC was a non-regression test, but it should be fine either way.
