### PR TITLE
Decrease depth for other moves if we have found at least one score improvement and we did not fail high

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,917 bytes
+3,914 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,922 bytes
+3,921 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,914 bytes
+3,918 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,918 bytes
+3,912 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,912 bytes
+3,918 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,897 bytes
+3,922 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,919 bytes
+3,917 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,921 bytes
+3,919 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,10 +544,12 @@ i32 alphabeta(Position &pos,
     Move tt_move{};
     if (tt_entry.key == tt_key) {
         tt_move = tt_entry.move;
-        if (ply > 0 && tt_entry.depth >= depth)
+        if (ply > 0 && tt_entry.depth >= depth) {
             if (tt_entry.flag == Upper && tt_entry.score <= alpha || tt_entry.flag == Lower && tt_entry.score >= beta ||
-                tt_entry.flag == Exact)
+                tt_entry.flag == Exact) {
                 return tt_entry.score;
+            }
+        }
     }
     // Internal iterative reduction
     else if (depth > 3)
@@ -626,11 +628,12 @@ i32 alphabeta(Position &pos,
         // Find best move remaining
         i32 best_move_index = i;
         if (i == 0 && !(no_move == tt_move)) {
-            for (i32 j = i; j < num_moves; ++j)
+            for (i32 j = i; j < num_moves; ++j) {
                 if (moves[j] == tt_move) {
                     best_move_index = j;
                     break;
                 }
+            }
         } else
             for (i32 j = i; j < num_moves; ++j)
                 if (move_scores[j] > move_scores[best_move_index])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -729,9 +729,10 @@ i32 alphabeta(Position &pos,
         if (score > best_score) {
             best_score = score;
             if (score > alpha) {
-                best_move = stack[ply].move = move;
+                best_move = move;
                 tt_flag = Exact;
                 alpha = score;
+                stack[ply].move = move;
                 if (score < beta && depth > 1 && beta < 16384 && score > -16384)
                     depth--;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -728,11 +728,16 @@ i32 alphabeta(Position &pos,
 
         if (score > best_score) {
             best_score = score;
-            best_move = move;
             if (score > alpha) {
+                best_move = move;
                 tt_flag = Exact;
                 alpha = score;
                 stack[ply].move = move;
+                if (score < beta) {
+                    if (depth > 1 && beta < 16384 && score > -16384)
+                        depth -= 1;
+                    alpha = score;
+                }
             }
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -729,12 +729,10 @@ i32 alphabeta(Position &pos,
         if (score > best_score) {
             best_score = score;
             if (score > alpha) {
-                best_move = move;
+                best_move = stack[ply].move = move;
                 tt_flag = Exact;
                 alpha = score;
-                stack[ply].move = move;
-                if (score < beta && depth > 1 && beta < 16384 && score > -16384)
-                    depth -= 1;
+                depth -= (score < beta && depth > 1 && beta < 16384 && score > -16384);
             }
         }
 
@@ -742,10 +740,9 @@ i32 alphabeta(Position &pos,
             tt_flag = Lower;
             if (!gain) {
                 hh_table[pos.flipped][move.from][move.to] += depth * depth;
-                for (i32 j = 0; j < num_quiets_evaluated - 1; ++j) {
+                for (i32 j = 0; j < num_quiets_evaluated - 1; ++j)
                     hh_table[pos.flipped][stack[ply].quiets_evaluated[j].from][stack[ply].quiets_evaluated[j].to] -=
                         depth * depth;
-                }
                 stack[ply].killer = move;
             }
             break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,12 +544,10 @@ i32 alphabeta(Position &pos,
     Move tt_move{};
     if (tt_entry.key == tt_key) {
         tt_move = tt_entry.move;
-        if (ply > 0 && tt_entry.depth >= depth) {
+        if (ply > 0 && tt_entry.depth >= depth)
             if (tt_entry.flag == Upper && tt_entry.score <= alpha || tt_entry.flag == Lower && tt_entry.score >= beta ||
-                tt_entry.flag == Exact) {
+                tt_entry.flag == Exact)
                 return tt_entry.score;
-            }
-        }
     }
     // Internal iterative reduction
     else if (depth > 3)
@@ -628,12 +626,11 @@ i32 alphabeta(Position &pos,
         // Find best move remaining
         i32 best_move_index = i;
         if (i == 0 && !(no_move == tt_move)) {
-            for (i32 j = i; j < num_moves; ++j) {
+            for (i32 j = i; j < num_moves; ++j)
                 if (moves[j] == tt_move) {
                     best_move_index = j;
                     break;
                 }
-            }
         } else
             for (i32 j = i; j < num_moves; ++j)
                 if (move_scores[j] > move_scores[best_move_index])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -733,9 +733,8 @@ i32 alphabeta(Position &pos,
                 tt_flag = Exact;
                 alpha = score;
                 stack[ply].move = move;
-                if (score < beta) {
-                    if (depth > 1 && beta < 16384 && score > -16384)
-                        depth -= 1;
+                if (depth > 1 && score < beta && beta < 16384 && score > -16384) {
+                    depth -= 1;
                     alpha = score;
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1091,9 +1091,10 @@ i32 main(
                 cin >> thread_count;
                 thread_count = max(1, min(256, thread_count));
             } else if (word == "Hash") {
+                i32 megabytes = 1;
                 cin >> word;
-                cin >> num_tt_entries;
-                num_tt_entries = min(max(num_tt_entries, 1ULL), 65536ULL) * 1024 * 1024 / sizeof(TT_Entry);
+                cin >> megabytes;
+                num_tt_entries = static_cast<u64>(min(max(megabytes, 1), 65536)) * 1024 * 1024 / sizeof(TT_Entry);
                 transposition_table.clear();
                 transposition_table.resize(num_tt_entries);
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -733,7 +733,7 @@ i32 alphabeta(Position &pos,
                 tt_flag = Exact;
                 alpha = score;
                 stack[ply].move = move;
-                if (depth > 1 && score < beta && beta < 16384 && score > -16384) {
+                if (score < beta && depth > 1 && beta < 16384 && score > -16384) {
                     depth -= 1;
                     alpha = score;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -733,10 +733,8 @@ i32 alphabeta(Position &pos,
                 tt_flag = Exact;
                 alpha = score;
                 stack[ply].move = move;
-                if (score < beta && depth > 1 && beta < 16384 && score > -16384) {
+                if (score < beta && depth > 1 && beta < 16384 && score > -16384)
                     depth -= 1;
-                    alpha = score;
-                }
             }
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -732,7 +732,8 @@ i32 alphabeta(Position &pos,
                 best_move = stack[ply].move = move;
                 tt_flag = Exact;
                 alpha = score;
-                depth -= (score < beta && depth > 1 && beta < 16384 && score > -16384);
+                if (score < beta && depth > 1 && beta < 16384 && score > -16384)
+                    depth--;
             }
         }
 


### PR DESCRIPTION
This patch was inspired by a feature in stockfish.

Passed STC:
```
ELO   | 8.16 +- 5.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8136 W: 2383 L: 2192 D: 3561
```
http://chess.grantnet.us/test/32270/

Passed LTC:
```
ELO   | 6.90 +- 4.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9520 W: 2487 L: 2298 D: 4735
```
http://chess.grantnet.us/test/32272/

+21 bytes
Bench 3243028