### PR TITLE
Smaller bestmove

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,899 bytes
+3,894 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,986 bytes
+3,889 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,894 bytes
+3,912 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,901 bytes
+3,896 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,901 bytes
+3,986 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,896 bytes
+3,894 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -676,9 +676,9 @@ i32 alphabeta(Position &pos,
         } else {
             // Late move reduction
             i32 reduction = depth > 2 && num_moves_evaluated > 4 && !gain
-                                ? 1 + num_moves_evaluated / 14 + depth / 17 + (alpha == beta - 1) - improving +
-                                      (hh_table[pos.flipped][move.from][move.to] < 0) -
-                                      (hh_table[pos.flipped][move.from][move.to] > 0)
+                                ? num_moves_evaluated / 14 + depth / 17 + (alpha == beta - 1) + !improving +
+                                  (hh_table[pos.flipped][move.from][move.to] < 0) -
+                                  (hh_table[pos.flipped][move.from][move.to] > 0)
                                 : 0;
 
         zero_window:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -677,8 +677,8 @@ i32 alphabeta(Position &pos,
             // Late move reduction
             i32 reduction = depth > 2 && num_moves_evaluated > 4 && !gain
                                 ? num_moves_evaluated / 14 + depth / 17 + (alpha == beta - 1) + !improving +
-                                  (hh_table[pos.flipped][move.from][move.to] < 0) -
-                                  (hh_table[pos.flipped][move.from][move.to] > 0)
+                                      (hh_table[pos.flipped][move.from][move.to] < 0) -
+                                      (hh_table[pos.flipped][move.from][move.to] > 0)
                                 : 0;
 
         zero_window:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -482,18 +482,12 @@ const i32 pawn_attacked[] = {S(-64, -14), S(-155, -142)};
     u64 hash = pos.flipped;
 
     // Pieces
-    for (i32 p = Pawn; p < None; p++) {
-        u64 copy = pos.pieces[p] & pos.colour[0];
+    for (i32 p = Pawn; p < None + 6; ++p) {
+        u64 copy = pos.pieces[p % 6] & pos.colour[p > 5];
         while (copy) {
             const i32 sq = lsb(copy);
             copy &= copy - 1;
             hash ^= keys[p * 64 + sq];
-        }
-        copy = pos.pieces[p] & pos.colour[1];
-        while (copy) {
-            const i32 sq = lsb(copy);
-            copy &= copy - 1;
-            hash ^= keys[(p + 6) * 64 + sq];
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -602,7 +602,7 @@ i32 alphabeta(Position &pos,
     i32 num_moves_evaluated = 0;
     i32 num_quiets_evaluated = 0;
     i32 best_score = -inf;
-    Move best_move{};
+    auto best_move = tt_move;
 
     auto &moves = stack[ply].moves;
     auto &move_scores = stack[ply].move_scores;
@@ -756,7 +756,7 @@ i32 alphabeta(Position &pos,
         return in_qsearch ? alpha : in_check ? ply - mate_score : 0;
 
     // Save to TT
-    tt_entry = {tt_key, best_move == no_move ? tt_move : best_move, best_score, in_qsearch ? 0 : depth, tt_flag};
+    tt_entry = {tt_key, best_move, best_score, in_qsearch ? 0 : depth, tt_flag};
 
     return alpha;
 }


### PR DESCRIPTION
-5 bytes

2 out of the 5 are from replacing `Move` to `auto`