### PR TITLE
Set static eval to TT score if conditions apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,923 bytes
+3,917 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,899 bytes
+3,923 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -556,14 +556,11 @@ i32 alphabeta(Position &pos,
     i32 static_eval = eval(pos);
     stack[ply].score = static_eval;
     const i32 improving = ply > 1 && static_eval > stack[ply - 2].score;
-    
 
     if (tt_entry.key == tt_key && (tt_entry.flag == Exact || tt_entry.flag == Lower && static_eval < tt_entry.score ||
                                    tt_entry.flag == Upper && static_eval > tt_entry.score)) {
         static_eval = tt_entry.score;
     }
-
-
 
     if (in_qsearch && static_eval > alpha) {
         if (static_eval >= beta)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,7 @@ struct [[nodiscard]] Stack {
     i32 score;
 };
 
+// Static eval using the TT relies on this specific ordering, do not change it.
 enum
 {
     Upper,
@@ -557,6 +558,8 @@ i32 alphabeta(Position &pos,
     stack[ply].score = static_eval;
     const i32 improving = ply > 1 && static_eval > stack[ply - 2].score;
 
+    // If static_eval <= tt_entry.score, tt_entry.flag has to be lower or exact for the condition to be true.
+    // Otherwise, tt_entry.flag has to be upper or exact.
     if (tt_entry.key == tt_key && tt_entry.flag + 1 & (static_eval <= tt_entry.score) + 1)
         static_eval = tt_entry.score;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -553,9 +553,17 @@ i32 alphabeta(Position &pos,
     else if (depth > 3)
         depth--;
 
-    const i32 static_eval = eval(pos);
+    i32 static_eval = eval(pos);
     stack[ply].score = static_eval;
     const i32 improving = ply > 1 && static_eval > stack[ply - 2].score;
+    
+
+    if (tt_entry.key == tt_key && (tt_entry.flag == Exact || tt_entry.flag == Lower && static_eval < tt_entry.score ||
+                                   tt_entry.flag == Upper && static_eval > tt_entry.score)) {
+        static_eval = tt_entry.score;
+    }
+
+
 
     if (in_qsearch && static_eval > alpha) {
         if (static_eval >= beta)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -557,10 +557,8 @@ i32 alphabeta(Position &pos,
     stack[ply].score = static_eval;
     const i32 improving = ply > 1 && static_eval > stack[ply - 2].score;
 
-    if (tt_entry.key == tt_key && (tt_entry.flag == Exact || tt_entry.flag == Lower && static_eval < tt_entry.score ||
-                                   tt_entry.flag == Upper && static_eval > tt_entry.score)) {
+    if (tt_entry.key == tt_key && tt_entry.flag + 1 & (static_eval <= tt_entry.score) + 1)
         static_eval = tt_entry.score;
-    }
 
     if (in_qsearch && static_eval > alpha) {
         if (static_eval >= beta)


### PR DESCRIPTION
STC:
```
ELO   | 10.94 +- 6.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5496 W: 1602 L: 1429 D: 2465
```
http://chess.grantnet.us/test/32668/

LTC:
```
ELO   | 17.57 +- 8.89 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3088 W: 891 L: 735 D: 1462
```
http://chess.grantnet.us/test/32670/

Bench: 4800494
+18 bytes