### PR TITLE
-10 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,903 bytes
+3,900 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,907 bytes
+3,903 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,900 bytes
+3,897 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1099,7 +1099,6 @@ i32 main(
             i32 time_left;
 
             // minify enable filter delete
-            i32 found = 0;
             while (true) {
                 cin >> word;
                 if (word == (pos.flipped ? "btime" : "wtime")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1096,33 +1096,32 @@ i32 main(
         }
         // minify disable filter delete
         else if (word == "go") {
-            i32 wtime;
-            i32 btime;
+            i32 time;
 
             // minify enable filter delete
             i32 found = 0;
-            while (found < 2) {
+            while (true) {
                 cin >> word;
-                if (word == "wtime") {
-                    cin >> wtime;
-                    found++;
-                } else if (word == "btime") {
-                    cin >> btime;
-                    found++;
+                if (word == (pos.flipped ? "btime" : "wtime")) {
+                    cin >> time;
+                    break;
                 }
             }
 
             goto search_start;
             // minify disable filter delete
 
-            cin >> word >> wtime >> word >> btime;
+            if (pos.flipped)
+                cin >> word >> word >> word >> time;
+            else
+                cin >> word >> time >> word >> word;
 
         // minify enable filter delete
         search_start:
             // minify disable filter delete
 
             const u64 start = now();
-            const u64 allocated_time = (pos.flipped ? btime : wtime) / 3;
+            const u64 allocated_time = time / 3;
 
             // Lazy SMP
             vector<thread> threads;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1113,7 +1113,7 @@ i32 main(
             if (pos.flipped)
                 cin >> word >> word >> word >> time_left;
             else
-                cin >> word >> time_left >> word >> word;
+                cin >> word >> time_left;
 
         // minify enable filter delete
         search_start:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1096,14 +1096,14 @@ i32 main(
         }
         // minify disable filter delete
         else if (word == "go") {
-            i32 time;
+            i32 time_left;
 
             // minify enable filter delete
             i32 found = 0;
             while (true) {
                 cin >> word;
                 if (word == (pos.flipped ? "btime" : "wtime")) {
-                    cin >> time;
+                    cin >> time_left;
                     break;
                 }
             }
@@ -1112,16 +1112,16 @@ i32 main(
             // minify disable filter delete
 
             if (pos.flipped)
-                cin >> word >> word >> word >> time;
+                cin >> word >> word >> word >> time_left;
             else
-                cin >> word >> time >> word >> word;
+                cin >> word >> time_left >> word >> word;
 
         // minify enable filter delete
         search_start:
             // minify disable filter delete
 
             const u64 start = now();
-            const u64 allocated_time = time / 3;
+            const u64 allocated_time = time_left / 3;
 
             // Lazy SMP
             vector<thread> threads;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1120,7 +1120,6 @@ i32 main(
             // minify disable filter delete
 
             const u64 start = now();
-            const u64 allocated_time = time_left / 3;
 
             // Lazy SMP
             vector<thread> threads;
@@ -1146,7 +1145,7 @@ i32 main(
                                                       total_nodes,
                                                       // minify disable filter delete
                                                       start,
-                                                      allocated_time,
+                                                      time_left / 3,
                                                       stop);
             stop = true;
             for (i32 i = 1; i < thread_count; ++i)


### PR DESCRIPTION
Instead of having a separate `wtime` and `btime` variable, use a single variable `time_left`.
Remove variables `found` and `allocated_time`.

-10 bytes
No functional change