### PR TITLE
Retain previous TT move if no moves raise alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,907 bytes
+3,900 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,897 bytes
+3,907 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,7 +544,7 @@ i32 alphabeta(Position &pos,
     Move tt_move{};
     if (tt_entry.key == tt_key) {
         tt_move = tt_entry.move;
-        if (ply > 0 && tt_entry.depth >= depth)
+        if (ply > 0 && alpha == beta - 1 && tt_entry.depth >= depth)
             if (tt_entry.flag == Upper && tt_entry.score <= alpha || tt_entry.flag == Lower && tt_entry.score >= beta ||
                 tt_entry.flag == Exact)
                 return tt_entry.score;
@@ -606,7 +606,7 @@ i32 alphabeta(Position &pos,
 
     i32 num_moves_evaluated = 0;
     i32 num_quiets_evaluated = 0;
-    i32 best_score = -inf;
+    i32 best_score = in_qsearch ? static_eval : -inf;
     auto best_move = tt_move;
 
     auto &moves = stack[ply].moves;
@@ -730,8 +730,8 @@ i32 alphabeta(Position &pos,
 
         if (score > best_score) {
             best_score = score;
-            best_move = move;
             if (score > alpha) {
+                best_move = move;
                 tt_flag = Exact;
                 alpha = score;
                 stack[ply].move = move;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,7 @@ struct [[nodiscard]] Stack {
     i32 score;
 };
 
-// Static eval using the TT (as well as TT cutoffs) relies on this specific ordering, do not change it.
+// Static eval using the TT and TT cutoffs rely on this specific ordering, do not change it.
 enum
 {
     Upper,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,7 @@ struct [[nodiscard]] Stack {
     i32 score;
 };
 
-// Static eval using the TT relies on this specific ordering, do not change it.
+// Static eval using the TT (as well as TT cutoffs) relies on this specific ordering, do not change it.
 enum
 {
     Upper,
@@ -545,8 +545,9 @@ i32 alphabeta(Position &pos,
     if (tt_entry.key == tt_key) {
         tt_move = tt_entry.move;
         if (ply > 0 && alpha == beta - 1 && tt_entry.depth >= depth)
-            if (tt_entry.flag == Upper && tt_entry.score <= alpha || tt_entry.flag == Lower && tt_entry.score >= beta ||
-                tt_entry.flag == Exact)
+            // If tt_entry.score >= beta, tt_entry.flag has to be lower or exact for the condition to be true.
+            // Otherwise, tt_entry.flag has to be upper or exact.
+            if (tt_entry.flag + 1 & (tt_entry.score >= beta) + 1)
                 return tt_entry.score;
     }
     // Internal iterative reduction


### PR DESCRIPTION
However as it is not good to do TT cutoffs if we are on the PV without a move, only do TT cutoffs on null window (aka non PV node).
This will scale better with time control IMO as it reduces pruning.

STC:
```
ELO   | 2.83 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 59888 W: 16856 L: 16368 D: 26664
```
http://chess.grantnet.us/test/32893/

LTC:
```
ELO   | 7.21 +- 5.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9104 W: 2421 L: 2232 D: 4451
```
http://chess.grantnet.us/test/32894/

+3 bytes
Bench 5665638