### PR TITLE
Switch to fail soft

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,895 bytes
+3,899 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -575,7 +575,7 @@ i32 alphabeta(Position &pos,
             if (depth < 7) {
                 const i32 margins[] = {0, 50, 100, 200, 300, 500, 800};
                 if (static_eval - margins[depth - improving] >= beta)
-                    return beta;
+                    return static_eval;
             }
 
             // Null move pruning
@@ -759,12 +759,12 @@ i32 alphabeta(Position &pos,
 
     // Return mate or draw scores if no moves found
     if (best_score == -inf)
-        return in_qsearch ? alpha : in_check ? ply - mate_score : 0;
+        return in_qsearch ? best_score : in_check ? ply - mate_score : 0;
 
     // Save to TT
     tt_entry = {tt_key, best_move, best_score, in_qsearch ? 0 : depth, tt_flag};
 
-    return alpha;
+    return best_score;
 }
 
 // minify enable filter delete


### PR DESCRIPTION
Switch to a fail soft framework

STC:
```
ELO   | 7.66 +- 5.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8752 W: 2530 L: 2337 D: 3885
```
http://chess.grantnet.us/test/32978/

LTC:
```
ELO   | 5.86 +- 4.39 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12040 W: 3127 L: 2924 D: 5989
```
http://chess.grantnet.us/test/32979/

+4 bytes
Bench 4932544