### PR TITLE
Do not set best score to alpha during delta pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,862 bytes
+3,866 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -645,10 +645,8 @@ i32 alphabeta(Position &pos,
         const i32 gain = max_material[move.promo] + max_material[piece_on(pos, move.to)];
 
         // Delta pruning
-        if (in_qsearch && !in_check && static_eval + 50 + gain < alpha) {
-            best_score = alpha;
+        if (in_qsearch && !in_check && static_eval + 50 + gain < alpha)
             break;
-        }
 
         // Forward futility pruning
         if (depth < 8 && !in_qsearch && !in_check && !(move == tt_move) && static_eval + 100 * depth + gain < alpha) {


### PR DESCRIPTION
Passed STC:
```
ELO   | 3.05 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 48024 W: 13618 L: 13197 D: 21209
```
http://chess.grantnet.us/test/33667/

Passed LTC:
```
ELO   | 3.89 +- 3.14 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 24016 W: 6272 L: 6003 D: 11741
```
http://chess.grantnet.us/test/33668/

+4 bytes