### PR TITLE
-24 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,931 bytes
+3,930 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,932 bytes
+3,931 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,930 bytes
+3,924 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,920 bytes
+3,909 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,924 bytes
+3,920 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,933 bytes
+3,932 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -734,20 +734,18 @@ i32 alphabeta(Position &pos,
                 alpha = score;
                 stack[ply].move = move;
             }
-        }
-
-        if (alpha >= beta) {
-            tt_flag = Lower;
-            if (!gain) {
-                hh_table[pos.flipped][move.from][move.to] += depth * depth;
-                for (i32 j = 0; j < num_quiets_evaluated - 1; ++j)
-                    hh_table[pos.flipped][stack[ply].quiets_evaluated[j].from][stack[ply].quiets_evaluated[j].to] -=
-                        depth * depth;
-                stack[ply].killer = move;
+            if (score >= beta) {
+                tt_flag = Lower;
+                if (!gain) {
+                    hh_table[pos.flipped][move.from][move.to] += depth * depth;
+                    for (i32 j = 0; j < num_quiets_evaluated - 1; ++j)
+                        hh_table[pos.flipped][stack[ply].quiets_evaluated[j].from][stack[ply].quiets_evaluated[j].to] -=
+                            depth * depth;
+                    stack[ply].killer = move;
+                }
+                break;
             }
-            break;
         }
-
         // Late move pruning based on quiet move count
         if (!in_check && alpha == beta - 1 && num_quiets_evaluated > 3 + depth * depth >> !improving)
             break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -559,8 +559,8 @@ i32 alphabeta(Position &pos,
             return tt_entry.score;
     }
     // Internal iterative reduction
-    else if (depth > 3)
-        depth--;
+    else
+        depth -= depth > 3;
 
     i32 static_eval = stack[ply].score = eval(pos);
     const i32 improving = ply > 1 && static_eval > stack[ply - 2].score;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -733,17 +733,17 @@ i32 alphabeta(Position &pos,
                 tt_flag = Exact;
                 alpha = score;
                 stack[ply].move = move;
-            }
-            if (score >= beta) {
-                tt_flag = Lower;
-                if (!gain) {
-                    hh_table[pos.flipped][move.from][move.to] += depth * depth;
-                    for (i32 j = 0; j < num_quiets_evaluated - 1; ++j)
-                        hh_table[pos.flipped][stack[ply].quiets_evaluated[j].from][stack[ply].quiets_evaluated[j].to] -=
-                            depth * depth;
-                    stack[ply].killer = move;
+                if (score >= beta) {
+                    tt_flag = Lower;
+                    if (!gain) {
+                        hh_table[pos.flipped][move.from][move.to] += depth * depth;
+                        for (i32 j = 0; j < num_quiets_evaluated - 1; ++j)
+                            hh_table[pos.flipped][stack[ply].quiets_evaluated[j].from]
+                                    [stack[ply].quiets_evaluated[j].to] -= depth * depth;
+                        stack[ply].killer = move;
+                    }
+                    break;
                 }
-                break;
             }
         }
         // Late move pruning based on quiet move count

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -554,8 +554,7 @@ i32 alphabeta(Position &pos,
         tt_move = tt_entry.move;
         if (alpha == beta - 1 && tt_entry.depth >= depth && tt_entry.flag != tt_entry.score <= alpha)
             // If tt_entry.score <= alpha, tt_entry.flag cannot be Lower (ie must be Upper or Exact).
-            // Otherwise, tt_entry.flag cannot be
-            // Upper (ie must be Lower or Exact).
+            // Otherwise, tt_entry.flag cannot be Upper (ie must be Lower or Exact).
             return tt_entry.score;
     }
     // Internal iterative reduction

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -631,16 +631,14 @@ i32 alphabeta(Position &pos,
 
         // Find best move remaining
         i32 best_move_index = i;
-        if (i == 0 && !(no_move == tt_move)) {
-            for (i32 j = i; j < num_moves; ++j)
-                if (moves[j] == tt_move) {
-                    best_move_index = j;
-                    break;
-                }
-        } else
-            for (i32 j = i; j < num_moves; ++j)
-                if (move_scores[j] > move_scores[best_move_index])
-                    best_move_index = j;
+        for (i32 j = i; j < num_moves; ++j) {
+            if (moves[j] == tt_move) {
+                best_move_index = j;
+                break;
+            }
+            if (move_scores[j] > move_scores[best_move_index])
+                best_move_index = j;
+        }
 
         const Move move = moves[best_move_index];
         moves[best_move_index] = moves[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -615,6 +615,7 @@ i32 alphabeta(Position &pos,
 
     auto &moves = stack[ply].moves;
     auto &move_scores = stack[ply].move_scores;
+    auto &quiets_evaluated = stack[ply].quiets_evaluated;
     const i32 num_moves = movegen(pos, moves, in_qsearch);
 
     for (i32 i = 0; i < num_moves; ++i) {
@@ -724,7 +725,7 @@ i32 alphabeta(Position &pos,
 
         num_moves_evaluated++;
         if (!gain)
-            stack[ply].quiets_evaluated[num_quiets_evaluated++] = move;
+            quiets_evaluated[num_quiets_evaluated++] = move;
 
         if (score > best_score) {
             best_score = score;
@@ -738,8 +739,7 @@ i32 alphabeta(Position &pos,
                     if (!gain) {
                         hh_table[pos.flipped][move.from][move.to] += depth * depth;
                         for (i32 j = 0; j < num_quiets_evaluated - 1; ++j)
-                            hh_table[pos.flipped][stack[ply].quiets_evaluated[j].from]
-                                    [stack[ply].quiets_evaluated[j].to] -= depth * depth;
+                            hh_table[pos.flipped][quiets_evaluated[j].from][quiets_evaluated[j].to] -= depth * depth;
                         stack[ply].killer = move;
                     }
                     break;


### PR DESCRIPTION
Tested for no regression:
```
Elo   | 3.36 +- 4.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 13322 W: 3866 L: 3737 D: 5719
Penta | [255, 1274, 3502, 1347, 283]
http://chess.grantnet.us/test/34110/
```

No functional change