### PR TITLE
Use mobility in evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,918 bytes
+3,961 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,37 +354,38 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {127, 412, 441, 767, 1468, 0, 0};
-const i32 material[] = {S(106, 127), S(377, 412), S(394, 441), S(492, 767), S(977, 1468), 0};
+const i32 max_material[] = {157, 504, 505, 922, 1839, 0, 0};
+const i32 material[] = {S(87, 157), S(278, 504), S(289, 505), S(385, 922), S(686, 1839), 0};
 const i32 pst_rank[][8] = {
-    {0, S(-3, 0), S(-3, -1), S(-1, -1), S(2, 0), S(5, 2), 0, 0},
-    {S(-6, -5), S(-4, -2), S(-1, 0), S(1, 3), S(5, 4), S(10, 1), S(6, -1), S(-11, -1)},
-    {S(-5, -3), S(-1, -2), S(1, 0), S(2, 2), S(3, 2), S(6, 1), S(2, 0), S(-8, 0)},
-    {S(-2, -2), S(-4, -3), S(-5, -2), S(-4, 0), S(-1, 1), S(3, 1), S(5, 2), S(8, 1)},
-    {S(-2, -11), S(0, -9), S(0, -4), S(-2, 2), S(-1, 6), S(3, 4), S(-1, 7), S(4, 4)},
-    {S(0, -5), S(0, -1), S(-2, 0), S(-5, 2), S(-2, 3), S(6, 2), S(3, 1), S(2, -4)},
+    {0, S(-2, 0), S(-3, -1), S(-1, -1), S(1, 0), S(4, 3), 0, 0},
+    {S(-4, -5), S(-2, -3), S(-1, -1), S(1, 3), S(3, 4), S(7, 1), S(5, 0), S(-10, 1)},
+    {S(-2, -2), S(1, -2), S(1, -1), S(1, 0), S(2, 1), S(4, 0), S(1, 1), S(-8, 3)},
+    {S(-2, -4), S(-3, -4), S(-4, -3), S(-4, 1), S(0, 2), S(3, 2), S(3, 3), S(6, 2)},
+    {S(1, -13), S(1, -11), S(0, -6), S(-1, 1), S(-1, 6), S(1, 6), S(-2, 9), S(1, 8)},
+    {S(0, -6), S(0, -2), S(-1, 0), S(-3, 3), S(0, 5), S(5, 5), S(4, 2), S(3, -5)},
 };
 const i32 pst_file[][8] = {
-    {S(-2, 0), S(-1, 1), S(-1, 0), S(0, -1), S(1, 0), S(2, 0), S(3, 0), S(-2, 0)},
-    {S(-6, -3), S(-2, -1), S(1, 2), S(2, 3), S(2, 3), S(3, 1), S(1, -1), S(-2, -4)},
-    {S(-3, -2), 0, S(1, 0), S(0, 2), S(0, 2), S(0, 1), S(2, -1), S(-1, -2)},
-    {S(-1, 0), S(-2, 1), S(-1, 1), 0, S(1, -1), S(2, 0), S(2, 0), S(-1, -1)},
-    {S(-3, -5), S(-2, -2), S(-1, 0), S(0, 1), S(0, 3), S(1, 3), S(3, 0), S(2, 0)},
-    {S(-2, -3), S(1, -1), S(-3, 1), S(-5, 2), S(-5, 2), S(-2, 1), S(1, 0), S(1, -3)},
+    {S(-1, 1), S(-1, 1), S(-1, 0), S(0, -1), S(1, 0), S(2, 0), S(2, 0), S(-1, -1)},
+    {S(-4, -4), S(-2, -1), S(0, 2), S(2, 3), S(2, 3), S(2, 1), S(1, -1), S(0, -3)},
+    {S(-2, 0), S(0, -1), S(1, 0), S(0, 1), S(0, 1), S(-1, 0), S(1, 0), S(0, -1)},
+    {S(-2, 0), S(-2, 1), S(-1, 1), S(1, 0), S(1, -1), S(1, 0), S(2, -1), S(-1, -1)},
+    {S(-3, -5), S(-2, -3), S(-1, -1), S(-1, 1), S(0, 2), S(0, 3), S(2, 2), S(3, 1)},
+    {S(-2, -5), S(2, -1), S(-2, 1), S(-5, 3), S(-4, 2), S(-3, 2), S(2, -1), S(1, -5)},
 };
 const i32 open_files[][5] = {
-    {S(0, 2), S(-7, 16), S(28, 20), S(6, 18), S(-25, 8)},
-    {S(-4, -12), S(-12, -2), S(58, 11), S(-7, 39), S(-70, -4)},
+    {S(2, 5), S(-4, 20), S(19, 16), S(4, 15), S(-23, 9)},
+    {S(-2, -13), S(-7, -2), S(44, 3), S(-7, 25), S(-58, -2)},
 };
-const i32 pawn_protection[] = {S(26, 13), S(5, 15), S(3, 6), S(10, 4), S(-9, 12), S(-35, 24)};
-const i32 passers[] = {S(-8, 11), S(16, 42), S(48, 105), S(197, 185)};
-const i32 pawn_passed_protected = S(15, 18);
-const i32 pawn_doubled = S(-15, -34);
-const i32 pawn_phalanx = S(12, 12);
-const i32 pawn_passed_blocked[] = {S(-8, -13), S(9, -37), S(9, -74), S(17, -97)};
-const i32 pawn_passed_king_distance[] = {S(2, -6), S(-4, 10)};
-const i32 bishop_pair = S(33, 65);
-const i32 king_shield[] = {S(42, -10), S(32, -9)};
+const i32 mobilities[] = {S(7, 5), S(7, 8), S(3, 5), S(3, 3), S(-3, -1)};
+const i32 pawn_protection[] = {S(23, 15), S(0, 20), S(7, 19), S(8, 9), S(-6, 23), S(-35, 27)};
+const i32 passers[] = {S(-3, 20), S(25, 58), S(61, 133), S(206, 226)};
+const i32 pawn_passed_protected = S(10, 21);
+const i32 pawn_doubled = S(-11, -42);
+const i32 pawn_phalanx = S(13, 14);
+const i32 pawn_passed_blocked[] = {S(-7, -19), S(7, -47), S(9, -90), S(-3, -93)};
+const i32 pawn_passed_king_distance[] = {S(1, -7), S(-3, 11)};
+const i32 bishop_pair = S(24, 81);
+const i32 king_shield[] = {S(33, -9), S(25, -7)};
 const i32 pawn_attacked[] = {S(-64, -14), S(-155, -142)};
 
 [[nodiscard]] i32 eval(Position &pos) {
@@ -457,6 +458,24 @@ const i32 pawn_attacked[] = {S(-64, -14), S(-155, -142)};
                         // If we're to move, we'll just lose some options and our tempo.
                         // If we're not to move, we lose a piece?
                         score += pawn_attacked[c];
+
+                    u64 mobility = 0;
+
+                    // Rook, Queen, King
+                    if (p > Bishop)
+                        mobility = rook(sq, pos.colour[0] | pos.colour[1]);
+
+                    // Knight
+                    if (p == Knight)
+                        mobility = knight(sq, pos.colour[0] | pos.colour[1]);
+
+                    // Bishop, Queen, King
+                    else if (p != Rook)
+                        mobility |= bishop(sq, pos.colour[0] | pos.colour[1]);
+
+                    // Use Queen mobilities for the king as a form of king safety.
+                    // Don't consider squares attacked by opponent pawns.
+                    score += mobilities[p - 1] * count(mobility & ~pos.colour[0] & ~attacked_by_pawns);
 
                     // Open or semi-open files
                     const u64 file_bb = 0x101010101010101ULL << file;


### PR DESCRIPTION
Tuned using previously used stoofvlees data (full dataset), in addition to 900k fens each of https://drive.google.com/file/d/1Y3haCS_zQH8dfEfKfj1YiWVdSCPYS__e/view and https://drive.google.com/file/d/1PdU6oLAHIqAfhattt-yc5Lh-wR1AvWyz/view

Tuner used is https://github.com/GediminasMasaitis/texel-tuner, with 3k epochs and qsearch enabled.

Passed STC SPRT:
```
Elo   | 20.98 +- 10.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2752 W: 923 L: 757 D: 1072
Penta | [77, 300, 522, 334, 143]
http://chess.grantnet.us/test/34161/
```

Passed LTC SPRT:
```
Elo   | 24.51 +- 11.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2116 W: 694 L: 545 D: 877
Penta | [44, 209, 442, 280, 83]
http://chess.grantnet.us/test/34162/
```

To get an accurate elo judgement, 20k games at LTC was run.
```
Elo   | 30.55 +- 3.65 (95%)
Conf  | 40.0+0.40s Threads=1 Hash=64MB
Games | N: 20010 W: 6636 L: 4881 D: 8493
Penta | [369, 2072, 3859, 2845, 860]
http://chess.grantnet.us/test/34163/
```

3961 bytes
+43 bytes, 0.72 elo/byte
