### PR TITLE
Combine 2 small search tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,934 bytes
+3,936 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -600,7 +600,7 @@ i32 alphabeta(Position &pos,
 
     if (in_qsearch && static_eval > alpha) {
         if (static_eval >= beta)
-            return beta;
+            return static_eval;
         alpha = static_eval;
     }
 
@@ -614,7 +614,8 @@ i32 alphabeta(Position &pos,
         }
 
         // Null move pruning
-        if (depth > 2 && static_eval >= beta && do_null && pos.colour[0] & ~(pos.pieces[Pawn] | pos.pieces[King])) {
+        if (depth > 2 && static_eval >= beta && static_eval >= stack[ply].score && do_null &&
+            pos.colour[0] & ~(pos.pieces[Pawn] | pos.pieces[King])) {
             Position npos = pos;
             flip(npos);
             npos.ep = 0;


### PR DESCRIPTION
Make stand-pat cutoffs fail-soft, as well as tweaking the conditions for NMP to occur.

Passed STC:
Elo   | 8.51 +- 5.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7346 W: 2165 L: 1985 D: 3196
Penta | [215, 844, 1417, 940, 257]
http://chess.grantnet.us/test/34346/

Passed LTC:
Elo   | 6.82 +- 5.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8616 W: 2315 L: 2146 D: 4155
Penta | [154, 1011, 1863, 1072, 208]
http://chess.grantnet.us/test/34350/

+2 bytes

Bench 5363136