### PR TITLE
King attack evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,999 bytes
+4,018 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,49 +354,50 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {140, 448, 451, 844, 1674, 0, 0};
-const i32 material[] = {S(93, 140), S(341, 448), S(350, 451), S(464, 844), S(838, 1674), 0};
+const i32 max_material[] = {139, 450, 453, 849, 1685, 0, 0};
+const i32 material[] = {S(95, 139), S(339, 450), S(348, 453), S(461, 849), S(832, 1685), 0};
 const i32 pst_rank[] = {
-    0,         S(-2, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
-    S(-3, -5), S(-1, -3), S(0, -1),  S(2, 3),   S(4, 3),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
-    S(-1, -2), S(1, -1),  S(1, 0),   S(1, 0),   S(2, 1),  S(3, 0), 0,        S(-9, 2),   // Bishop
-    S(-1, -3), S(-2, -3), S(-3, -2), S(-3, 1),  S(-1, 2), S(2, 2), S(3, 3),  S(5, 1),    // Rook
-    S(1, -12), S(2, -9),  S(0, -5),  S(-1, 1),  S(-1, 6), S(1, 5), S(-2, 8), S(1, 6),    // Queen
-    S(0, -6),  S(0, -2),  S(-2, 0),  S(-4, 3),  S(-1, 4), S(5, 4), S(3, 2),  S(4, -4),   // King
+    0,         S(-3, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
+    S(-3, -5), S(-1, -3), S(0, -1),  S(2, 2),   S(3, 4),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
+    S(-1, -2), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-8, 2),   // Bishop
+    S(0, -3),  S(-1, -3), S(-2, -2), S(-3, 1),  S(0, 2),  S(2, 2), S(1, 3),  S(3, 1),    // Rook
+    S(2, -11), S(2, -9),  S(1, -4),  S(-1, 1),  S(-1, 5), S(0, 5), S(-3, 7), S(-1, 5),   // Queen
+    S(-1, -5), S(1, -2),  0,         S(-2, 2),  S(0, 4),  S(6, 4), S(4, 2),  S(3, -4)    // King
 };
 const i32 pst_file[] = {
     S(-1, 1),  S(-2, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, -1),  // Pawn
     S(-5, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  S(1, 0),  S(-1, -3),  // Knight
     S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(1, 1),  S(-1, 1), S(2, 0),  S(0, -1),   // Bishop
-    S(-2, 0),  S(-2, 1),  S(-1, 1), S(1, 0),  S(1, -1), S(1, 0),  S(2, 0),  S(-1, -1),  // Rook
-    S(-3, -5), S(-2, -3), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 3),  S(2, 2),  S(3, -1),   // Queen
-    S(-2, -5), S(2, -2),  S(-2, 1), S(-3, 2), S(-4, 2), S(-1, 1), S(2, -1), S(0, -5),   // King
+    S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(2, -1), S(1, 0),  S(1, 0),  S(-2, 0),   // Rook
+    S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(2, -1),   // Queen
+    S(-3, -5), S(2, -2),  S(-1, 1), S(-2, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
 };
 const i32 open_files[] = {
     // Semi open files
-    S(1, 4),
+    S(2, 4),
     S(-5, 20),
-    S(19, 15),
-    S(2, 17),
-    S(-24, 10),
+    S(18, 15),
+    S(3, 18),
+    S(-22, 10),
     // Open files
-    S(-3, -13),
+    S(-3, -12),
     S(-11, -1),
-    S(48, 0),
-    S(-14, 34),
-    S(-63, 2),
+    S(46, 0),
+    S(-14, 37),
+    S(-60, 1),
 };
-const i32 mobilities[] = {S(8, 5), S(8, 7), S(4, 4), S(4, 3), S(-5, -1)};
-const i32 pawn_protection[] = {S(22, 14), S(2, 15), S(8, 17), S(8, 9), S(-5, 23), S(-32, 25)};
-const i32 pawn_threat[] = {S(-4, 1), S(18, 2), S(12, 5), S(9, 16), S(8, 17), S(2, 6)};
-const i32 passers[] = {S(4, 14), S(34, 50), S(66, 124), S(214, 209)};
-const i32 pawn_passed_protected = S(10, 20);
-const i32 pawn_doubled_penalty = S(10, 37);
+const i32 mobilities[] = {S(9, 5), S(8, 7), S(3, 4), S(4, 2), S(-5, 0)};
+const i32 king_attacks[] = {S(10, -5), S(18, -5), S(26, -10), S(19, 3), 0};
+const i32 pawn_protection[] = {S(22, 14), S(2, 15), S(7, 17), S(8, 10), S(-5, 20), S(-31, 25)};
+const i32 pawn_threat[] = {S(-4, 1), S(21, 1), S(12, 5), S(11, 17), S(9, 17), S(6, 5)};
+const i32 passers[] = {S(4, 14), S(35, 50), S(68, 124), S(220, 207)};
+const i32 pawn_passed_protected = S(11, 20);
+const i32 pawn_doubled_penalty = S(11, 37);
 const i32 pawn_phalanx = S(12, 11);
-const i32 pawn_passed_blocked_penalty[] = {S(8, 14), S(-6, 43), S(-9, 85), S(4, 99)};
+const i32 pawn_passed_blocked_penalty[] = {S(9, 14), S(-7, 43), S(-9, 85), S(4, 97)};
 const i32 pawn_passed_king_distance[] = {S(1, -6), S(-4, 11)};
 const i32 bishop_pair = S(32, 72);
-const i32 king_shield[] = {S(36, -12), S(28, -7)};
+const i32 king_shield[] = {S(36, -12), S(27, -7)};
 const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
 
 [[nodiscard]] i32 eval(Position &pos) {
@@ -491,6 +492,9 @@ const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
                     // Use Queen mobilities for the king as a form of king safety.
                     // Don't consider squares attacked by opponent pawns.
                     score += mobilities[p - 1] * count(mobility & ~pos.colour[0] & ~attacked_by_pawns);
+
+                    // Attacks on opponent king
+                    score += king_attacks[p - 1] * count(mobility & king(kings[1], pos.colour[0] | pos.colour[1]));
 
                     // Open or semi-open files
                     const u64 file_bb = 0x101010101010101ULL << file;


### PR DESCRIPTION
STC:
```
Elo   | 19.11 +- 9.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2894 W: 923 L: 764 D: 1207
Penta | [80, 306, 553, 391, 117]
```
http://chess.grantnet.us/test/34357/

LTC:
```
Elo   | 19.09 +- 9.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2642 W: 766 L: 621 D: 1255
Penta | [49, 272, 561, 363, 76]
````
http://chess.grantnet.us/test/34358/

+19 bytes