### PR TITLE
King attack evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,936 bytes
+3,978 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,48 +354,49 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {139, 449, 452, 841, 1674, 0, 0};
-const i32 material[] = {S(100, 139), S(329, 449), S(341, 452), S(455, 841), S(825, 1674), 0};
+const i32 max_material[] = {139, 449, 451, 843, 1678, 0, 0};
+const i32 material[] = {S(102, 139), S(329, 449), S(342, 451), S(455, 843), S(826, 1678), 0};
 const i32 pst_rank[] = {
     0,         S(-2, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
-    S(-4, -5), S(-2, -3), S(-1, -1), S(1, 3),   S(3, 4),  S(7, 1), S(5, 0),  S(-11, 1),  // Knight
-    S(-2, -2), S(1, -2),  S(1, 0),   S(1, 0),   S(2, 1),  S(4, 0), S(1, 0),  S(-8, 2),   // Bishop
-    S(-2, -4), S(-2, -4), S(-3, -2), S(-4, 1),  S(-1, 2), S(3, 2), S(3, 3),  S(6, 1),    // Rook
-    S(1, -13), S(1, -10), S(0, -5),  S(-1, 1),  S(-1, 6), S(1, 5), S(-2, 9), S(1, 7),    // Queen
-    S(0, -6),  S(0, -2),  S(-2, 0),  S(-4, 3),  S(-1, 4), S(5, 4), S(3, 3),  S(4, -4)    // King
+    S(-4, -5), S(-2, -3), S(-1, -1), S(2, 3),   S(3, 4),  S(7, 1), S(5, 0),  S(-11, 1),  // Knight
+    S(-2, -2), S(1, -2),  S(1, 0),   S(1, 0),   S(2, 1),  S(3, 0), S(1, 0),  S(-8, 2),   // Bishop
+    S(-1, -4), S(-2, -4), S(-3, -2), S(-3, 1),  S(0, 2),  S(3, 2), S(2, 4),  S(4, 2),    // Rook
+    S(2, -12), S(2, -9),  S(1, -4),  S(-1, 1),  S(-1, 6), S(0, 5), S(-2, 8), S(0, 6),    // Queen
+    S(-1, -5), S(1, -2),  0,         S(-2, 3),  S(0, 4),  S(6, 4), S(4, 3),  S(3, -4)    // King
 };
 const i32 pst_file[] = {
-    S(-2, 1),  S(-1, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, -1),  // Pawn
-    S(-4, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  S(1, -1), S(-1, -3),  // Knight
+    S(-2, 1),  S(-1, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-2, -1),  // Pawn
+    S(-4, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  0,        S(-1, -3),  // Knight
     S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(0, 1),  S(-1, 1), S(2, -1), S(0, -1),   // Bishop
-    S(-2, 0),  S(-2, 1),  S(-1, 1), S(1, 0),  S(1, -1), S(1, 0),  S(2, 0),  S(-1, -1),  // Rook
-    S(-3, -4), S(-2, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 3),  S(2, 1),  S(3, -1),   // Queen
-    S(-2, -5), S(2, -1),  S(-2, 1), S(-3, 2), S(-4, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
+    S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(2, -1), S(1, 0),  S(1, 0),  S(-2, 0),   // Rook
+    S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(2, -1),   // Queen
+    S(-2, -5), S(2, -2),  S(-1, 1), S(-3, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
 };
 const i32 open_files[] = {
     // Semi open files
-    S(3, 4),
-    S(-4, 20),
-    S(20, 16),
-    S(3, 19),
-    S(-23, 10),
+    S(3, 5),
+    S(-4, 21),
+    S(19, 16),
+    S(4, 19),
+    S(-21, 9),
     // Open files
     S(-3, -12),
     S(-11, 0),
-    S(47, 0),
-    S(-13, 35),
-    S(-63, 1),
+    S(46, 0),
+    S(-14, 38),
+    S(-60, 0),
 };
-const i32 mobilities[] = {S(9, 5), S(8, 7), S(4, 4), S(4, 3), S(-5, -1)};
-const i32 pawn_protection[] = {S(24, 14), S(2, 16), S(8, 17), S(9, 8), S(-5, 23), S(-34, 26)};
-const i32 passers[] = {S(0, 15), S(29, 52), S(63, 126), S(209, 210)};
+const i32 mobilities[] = {S(9, 5), S(7, 7), S(3, 4), S(4, 2), S(-5, 0)};
+const i32 king_attacks[] = {S(8, -4), S(18, -4), S(26, -10), S(19, 3), 0};
+const i32 pawn_protection[] = {S(24, 14), S(2, 15), S(7, 18), S(9, 9), S(-5, 19), S(-32, 25)};
+const i32 passers[] = {S(2, 15), S(32, 51), S(66, 124), S(215, 207)};
 const i32 pawn_passed_protected = S(13, 20);
-const i32 pawn_doubled_penalty = S(14, 38);
+const i32 pawn_doubled_penalty = S(15, 38);
 const i32 pawn_phalanx = S(13, 12);
-const i32 pawn_passed_blocked_penalty[] = {S(10, 14), S(-5, 43), S(-9, 86), S(3, 101)};
-const i32 pawn_passed_king_distance[] = {S(1, -6), S(-4, 11)};
-const i32 bishop_pair = S(31, 72);
-const i32 king_shield[] = {S(35, -12), S(28, -8)};
+const i32 pawn_passed_blocked_penalty[] = {S(11, 14), S(-5, 43), S(-9, 86), S(3, 99)};
+const i32 pawn_passed_king_distance[] = {S(1, -6), S(-3, 11)};
+const i32 bishop_pair = S(32, 71);
+const i32 king_shield[] = {S(35, -12), S(27, -7)};
 const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
 
 [[nodiscard]] i32 eval(Position &pos) {
@@ -486,6 +487,9 @@ const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
                     // Use Queen mobilities for the king as a form of king safety.
                     // Don't consider squares attacked by opponent pawns.
                     score += mobilities[p - 1] * count(mobility & ~pos.colour[0] & ~attacked_by_pawns);
+
+                    // Attacks on opponent king
+                    score += king_attacks[p - 1] * count(mobility & king(kings[1], pos.colour[0] | pos.colour[1]));
 
                     // Open or semi-open files
                     const u64 file_bb = 0x101010101010101ULL << file;


### PR DESCRIPTION
Results from testing in panic4:

STC:
```
Elo   | 19.11 +- 9.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2894 W: 923 L: 764 D: 1207
Penta | [80, 306, 553, 391, 117]
```
http://chess.grantnet.us/test/34357/

LTC:
```
Elo   | 19.09 +- 9.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2642 W: 766 L: 621 D: 1255
Penta | [49, 272, 561, 363, 76]
````
http://chess.grantnet.us/test/34358/

+42 bytes (same thing was +19 bytes in panic4)