### PR TITLE
King attacks and pawn threat evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,936 bytes
+3,978 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,978 bytes
+3,988 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,48 +354,49 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {139, 449, 452, 841, 1674, 0, 0};
-const i32 material[] = {S(100, 139), S(329, 449), S(341, 452), S(455, 841), S(825, 1674), 0};
+const i32 max_material[] = {139, 449, 451, 843, 1678, 0, 0};
+const i32 material[] = {S(102, 139), S(329, 449), S(342, 451), S(455, 843), S(826, 1678), 0};
 const i32 pst_rank[] = {
     0,         S(-2, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
-    S(-4, -5), S(-2, -3), S(-1, -1), S(1, 3),   S(3, 4),  S(7, 1), S(5, 0),  S(-11, 1),  // Knight
-    S(-2, -2), S(1, -2),  S(1, 0),   S(1, 0),   S(2, 1),  S(4, 0), S(1, 0),  S(-8, 2),   // Bishop
-    S(-2, -4), S(-2, -4), S(-3, -2), S(-4, 1),  S(-1, 2), S(3, 2), S(3, 3),  S(6, 1),    // Rook
-    S(1, -13), S(1, -10), S(0, -5),  S(-1, 1),  S(-1, 6), S(1, 5), S(-2, 9), S(1, 7),    // Queen
-    S(0, -6),  S(0, -2),  S(-2, 0),  S(-4, 3),  S(-1, 4), S(5, 4), S(3, 3),  S(4, -4)    // King
+    S(-4, -5), S(-2, -3), S(-1, -1), S(2, 3),   S(3, 4),  S(7, 1), S(5, 0),  S(-11, 1),  // Knight
+    S(-2, -2), S(1, -2),  S(1, 0),   S(1, 0),   S(2, 1),  S(3, 0), S(1, 0),  S(-8, 2),   // Bishop
+    S(-1, -4), S(-2, -4), S(-3, -2), S(-3, 1),  S(0, 2),  S(3, 2), S(2, 4),  S(4, 2),    // Rook
+    S(2, -12), S(2, -9),  S(1, -4),  S(-1, 1),  S(-1, 6), S(0, 5), S(-2, 8), S(0, 6),    // Queen
+    S(-1, -5), S(1, -2),  0,         S(-2, 3),  S(0, 4),  S(6, 4), S(4, 3),  S(3, -4)    // King
 };
 const i32 pst_file[] = {
-    S(-2, 1),  S(-1, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, -1),  // Pawn
-    S(-4, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  S(1, -1), S(-1, -3),  // Knight
+    S(-2, 1),  S(-1, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-2, -1),  // Pawn
+    S(-4, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  0,        S(-1, -3),  // Knight
     S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(0, 1),  S(-1, 1), S(2, -1), S(0, -1),   // Bishop
-    S(-2, 0),  S(-2, 1),  S(-1, 1), S(1, 0),  S(1, -1), S(1, 0),  S(2, 0),  S(-1, -1),  // Rook
-    S(-3, -4), S(-2, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 3),  S(2, 1),  S(3, -1),   // Queen
-    S(-2, -5), S(2, -1),  S(-2, 1), S(-3, 2), S(-4, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
+    S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(2, -1), S(1, 0),  S(1, 0),  S(-2, 0),   // Rook
+    S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(2, -1),   // Queen
+    S(-2, -5), S(2, -2),  S(-1, 1), S(-3, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
 };
 const i32 open_files[] = {
     // Semi open files
-    S(3, 4),
-    S(-4, 20),
-    S(20, 16),
-    S(3, 19),
-    S(-23, 10),
+    S(3, 5),
+    S(-4, 21),
+    S(19, 16),
+    S(4, 19),
+    S(-21, 9),
     // Open files
     S(-3, -12),
     S(-11, 0),
-    S(47, 0),
-    S(-13, 35),
-    S(-63, 1),
+    S(46, 0),
+    S(-14, 38),
+    S(-60, 0),
 };
-const i32 mobilities[] = {S(9, 5), S(8, 7), S(4, 4), S(4, 3), S(-5, -1)};
-const i32 pawn_protection[] = {S(24, 14), S(2, 16), S(8, 17), S(9, 8), S(-5, 23), S(-34, 26)};
-const i32 passers[] = {S(0, 15), S(29, 52), S(63, 126), S(209, 210)};
+const i32 mobilities[] = {S(9, 5), S(7, 7), S(3, 4), S(4, 2), S(-5, 0)};
+const i32 king_attacks[] = {S(8, -4), S(18, -4), S(26, -10), S(19, 3), 0};
+const i32 pawn_protection[] = {S(24, 14), S(2, 15), S(7, 18), S(9, 9), S(-5, 19), S(-32, 25)};
+const i32 passers[] = {S(2, 15), S(32, 51), S(66, 124), S(215, 207)};
 const i32 pawn_passed_protected = S(13, 20);
-const i32 pawn_doubled_penalty = S(14, 38);
+const i32 pawn_doubled_penalty = S(15, 38);
 const i32 pawn_phalanx = S(13, 12);
-const i32 pawn_passed_blocked_penalty[] = {S(10, 14), S(-5, 43), S(-9, 86), S(3, 101)};
-const i32 pawn_passed_king_distance[] = {S(1, -6), S(-4, 11)};
-const i32 bishop_pair = S(31, 72);
-const i32 king_shield[] = {S(35, -12), S(28, -8)};
+const i32 pawn_passed_blocked_penalty[] = {S(11, 14), S(-5, 43), S(-9, 86), S(3, 99)};
+const i32 pawn_passed_king_distance[] = {S(1, -6), S(-3, 11)};
+const i32 bishop_pair = S(32, 71);
+const i32 king_shield[] = {S(35, -12), S(27, -7)};
 const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
 
 [[nodiscard]] i32 eval(Position &pos) {
@@ -486,6 +487,9 @@ const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
                     // Use Queen mobilities for the king as a form of king safety.
                     // Don't consider squares attacked by opponent pawns.
                     score += mobilities[p - 1] * count(mobility & ~pos.colour[0] & ~attacked_by_pawns);
+
+                    // Attacks on opponent king
+                    score += king_attacks[p - 1] * count(mobility & king(kings[1], pos.colour[0] | pos.colour[1]));
 
                     // Open or semi-open files
                     const u64 file_bb = 0x101010101010101ULL << file;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,49 +354,50 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {139, 449, 451, 843, 1678, 0, 0};
-const i32 material[] = {S(102, 139), S(329, 449), S(342, 451), S(455, 843), S(826, 1678), 0};
+const i32 max_material[] = {139, 450, 453, 849, 1685, 0, 0};
+const i32 material[] = {S(95, 139), S(339, 450), S(348, 453), S(461, 849), S(832, 1685), 0};
 const i32 pst_rank[] = {
-    0,         S(-2, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
-    S(-4, -5), S(-2, -3), S(-1, -1), S(2, 3),   S(3, 4),  S(7, 1), S(5, 0),  S(-11, 1),  // Knight
-    S(-2, -2), S(1, -2),  S(1, 0),   S(1, 0),   S(2, 1),  S(3, 0), S(1, 0),  S(-8, 2),   // Bishop
-    S(-1, -4), S(-2, -4), S(-3, -2), S(-3, 1),  S(0, 2),  S(3, 2), S(2, 4),  S(4, 2),    // Rook
-    S(2, -12), S(2, -9),  S(1, -4),  S(-1, 1),  S(-1, 6), S(0, 5), S(-2, 8), S(0, 6),    // Queen
-    S(-1, -5), S(1, -2),  0,         S(-2, 3),  S(0, 4),  S(6, 4), S(4, 3),  S(3, -4)    // King
+    0,         S(-3, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
+    S(-3, -5), S(-1, -3), S(0, -1),  S(2, 2),   S(3, 4),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
+    S(-1, -2), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-8, 2),   // Bishop
+    S(0, -3),  S(-1, -3), S(-2, -2), S(-3, 1),  S(0, 2),  S(2, 2), S(1, 3),  S(3, 1),    // Rook
+    S(2, -11), S(2, -9),  S(1, -4),  S(-1, 1),  S(-1, 5), S(0, 5), S(-3, 7), S(-1, 5),   // Queen
+    S(-1, -5), S(1, -2),  0,         S(-2, 2),  S(0, 4),  S(6, 4), S(4, 2),  S(3, -4)    // King
 };
 const i32 pst_file[] = {
-    S(-2, 1),  S(-1, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-2, -1),  // Pawn
-    S(-4, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  0,        S(-1, -3),  // Knight
-    S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(0, 1),  S(-1, 1), S(2, -1), S(0, -1),   // Bishop
+    S(-1, 1),  S(-2, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, -1),  // Pawn
+    S(-5, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  S(1, 0),  S(-1, -3),  // Knight
+    S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(1, 1),  S(-1, 1), S(2, 0),  S(0, -1),   // Bishop
     S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(2, -1), S(1, 0),  S(1, 0),  S(-2, 0),   // Rook
     S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(2, -1),   // Queen
-    S(-2, -5), S(2, -2),  S(-1, 1), S(-3, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
+    S(-3, -5), S(2, -2),  S(-1, 1), S(-2, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
 };
 const i32 open_files[] = {
     // Semi open files
-    S(3, 5),
-    S(-4, 21),
-    S(19, 16),
-    S(4, 19),
-    S(-21, 9),
+    S(2, 4),
+    S(-5, 20),
+    S(18, 15),
+    S(3, 18),
+    S(-22, 10),
     // Open files
     S(-3, -12),
-    S(-11, 0),
+    S(-11, -1),
     S(46, 0),
-    S(-14, 38),
-    S(-60, 0),
+    S(-14, 37),
+    S(-60, 1),
 };
-const i32 mobilities[] = {S(9, 5), S(7, 7), S(3, 4), S(4, 2), S(-5, 0)};
-const i32 king_attacks[] = {S(8, -4), S(18, -4), S(26, -10), S(19, 3), 0};
-const i32 pawn_protection[] = {S(24, 14), S(2, 15), S(7, 18), S(9, 9), S(-5, 19), S(-32, 25)};
-const i32 passers[] = {S(2, 15), S(32, 51), S(66, 124), S(215, 207)};
-const i32 pawn_passed_protected = S(13, 20);
-const i32 pawn_doubled_penalty = S(15, 38);
-const i32 pawn_phalanx = S(13, 12);
-const i32 pawn_passed_blocked_penalty[] = {S(11, 14), S(-5, 43), S(-9, 86), S(3, 99)};
-const i32 pawn_passed_king_distance[] = {S(1, -6), S(-3, 11)};
-const i32 bishop_pair = S(32, 71);
-const i32 king_shield[] = {S(35, -12), S(27, -7)};
+const i32 mobilities[] = {S(9, 5), S(8, 7), S(3, 4), S(4, 2), S(-5, 0)};
+const i32 king_attacks[] = {S(10, -5), S(18, -5), S(26, -10), S(19, 3), 0};
+const i32 pawn_protection[] = {S(22, 14), S(2, 15), S(7, 17), S(8, 10), S(-5, 20), S(-31, 25)};
+const i32 pawn_threat_penalty[] = {S(-4, 1), S(21, 1), S(12, 5), S(11, 17), S(9, 17), S(6, 5)};
+const i32 passers[] = {S(4, 14), S(35, 50), S(68, 124), S(220, 207)};
+const i32 pawn_passed_protected = S(11, 20);
+const i32 pawn_doubled_penalty = S(11, 37);
+const i32 pawn_phalanx = S(12, 11);
+const i32 pawn_passed_blocked_penalty[] = {S(9, 14), S(-7, 43), S(-9, 85), S(4, 97)};
+const i32 pawn_passed_king_distance[] = {S(1, -6), S(-4, 11)};
+const i32 bishop_pair = S(32, 72);
+const i32 king_shield[] = {S(36, -12), S(27, -7)};
 const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
 
 [[nodiscard]] i32 eval(Position &pos) {
@@ -444,6 +445,10 @@ const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
                 if (piece_bb & protected_by_pawns)
                     score += pawn_protection[p];
 
+                // Pawn threat
+                if (0x101010101010101ULL << sq & ~piece_bb & attacked_by_pawns)
+                    score -= pawn_threat_penalty[p];
+
                 if (p == Pawn) {
                     // Passed pawns
                     if (rank > 2 && !(0x101010101010101ULL << sq & (pawns[1] | attacked_by_pawns))) {
@@ -489,7 +494,7 @@ const i32 pawn_attacked_penalty[] = {S(64, 14), S(155, 142)};
                     score += mobilities[p - 1] * count(mobility & ~pos.colour[0] & ~attacked_by_pawns);
 
                     // Attacks on opponent king
-                    score += king_attacks[p - 1] * count(mobility & king(kings[1], pos.colour[0] | pos.colour[1]));
+                    score += king_attacks[p - 1] * count(mobility & king(kings[1], 0));
 
                     // Open or semi-open files
                     const u64 file_bb = 0x101010101010101ULL << file;


### PR DESCRIPTION
STC fixed 20k games:
```
Elo   | 22.89 +- 3.71 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=8MB
Games | N: 20006 W: 6588 L: 5272 D: 8146
Penta | [524, 2067, 3839, 2715, 858]
```
http://chess.grantnet.us/test/34363/

LTC fixed 20k games:
```
Elo   | 25.67 +- 3.54 (95%)
Conf  | 40.0+0.40s Threads=1 Hash=64MB
Games | N: 20000 W: 6147 L: 4672 D: 9181
Penta | [314, 2096, 4101, 2779, 710]
```
http://chess.grantnet.us/test/34364/

+52 bytes