### PR TITLE
Save eval into TT

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,983 bytes
+4,002 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,000 bytes
+3,997 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,002 bytes
+4,000 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -589,21 +589,18 @@ i32 alphabeta(Position &pos,
     // TT Probing
     TT_Entry &tt_entry = transposition_table[tt_key % num_tt_entries];
     Move tt_move{};
-    i32 static_eval;
     if (tt_entry.key == tt_key) {
         tt_move = tt_entry.move;
-        static_eval = stack[ply].score = tt_entry.eval;
         if (alpha == beta - 1 && tt_entry.depth >= depth && tt_entry.flag != tt_entry.score < beta)
             // If tt_entry.score < beta, tt_entry.flag cannot be Lower (ie must be Upper or Exact).
             // Otherwise, tt_entry.flag cannot be Upper (ie must be Lower or Exact).
             return tt_entry.score;
-    } else {
-        static_eval = stack[ply].score = eval(pos);
-
-        // Internal iterative reduction
-        depth -= depth > 3;
     }
+    // Internal iterative reduction
+    else
+        depth -= depth > 3;
 
+    i32 static_eval = stack[ply].score = tt_entry.key == tt_key ? tt_entry.eval : eval(pos);
     const i32 improving = ply > 1 && static_eval > stack[ply - 2].score;
 
     // If static_eval > tt_entry.score, tt_entry.flag cannot be Lower (ie must be Upper or Exact).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -597,11 +597,6 @@ i32 alphabeta(Position &pos,
             // If tt_entry.score < beta, tt_entry.flag cannot be Lower (ie must be Upper or Exact).
             // Otherwise, tt_entry.flag cannot be Upper (ie must be Lower or Exact).
             return tt_entry.score;
-
-        // If static_eval > tt_entry.score, tt_entry.flag cannot be Lower (ie must be Upper or Exact).
-        // Otherwise, tt_entry.flag cannot be Upper (ie must be Lower or Exact).
-        if (tt_entry.flag != static_eval > tt_entry.score)
-            static_eval = tt_entry.score;
     } else {
         static_eval = stack[ply].score = eval(pos);
 
@@ -609,7 +604,12 @@ i32 alphabeta(Position &pos,
         depth -= depth > 3;
     }
 
-    const i32 improving = ply > 1 && stack[ply].score > stack[ply - 2].score;
+    const i32 improving = ply > 1 && static_eval > stack[ply - 2].score;
+
+    // If static_eval > tt_entry.score, tt_entry.flag cannot be Lower (ie must be Upper or Exact).
+    // Otherwise, tt_entry.flag cannot be Upper (ie must be Lower or Exact).
+    if (tt_entry.key == tt_key && tt_entry.flag != static_eval > tt_entry.score)
+        static_eval = tt_entry.score;
 
     if (in_qsearch && static_eval > alpha) {
         if (static_eval >= beta)


### PR DESCRIPTION
Passed STC:
Elo   | 6.57 +- 5.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9886 W: 2836 L: 2649 D: 4401
Penta | [263, 1138, 2005, 1223, 314]
http://chess.grantnet.us/test/34403/

Passed LTC:
Elo   | 3.81 +- 3.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 19514 W: 5008 L: 4794 D: 9712
Penta | [351, 2268, 4333, 2426, 379]
http://chess.grantnet.us/test/34405/

+14 bytes
Bench 5389378