### PR TITLE
Bishop colored pawns evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,989 bytes
+4,047 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,047 bytes
+4,048 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,048 bytes
+4,050 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,034 bytes
+4,031 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -570,7 +570,7 @@ const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
                     if (!(0x101010101010101ull << file & pawns[0]))
                         score += open_files[!(0x101010101010101ull << file & pawns[1]) * 5 + p - 1];
 
-                    // Pawns on bishop colored squares
+                    // Pawns on bishop coloured squares
                     if (p == Bishop) {
                         u64 mask = 0xAA55AA55AA55AA55ULL;
                         if (piece_bb & ~mask)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -572,8 +572,8 @@ const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
 
                     // Pawns on bishop colored squares
                     if (p == Bishop) {
-                        u64 mask = 0xAA55AA55AA55AA55UL;
-                        if (!(piece_bb & mask))
+                        u64 mask = 0xAA55AA55AA55AA55ULL;
+                        if (piece_bb & ~mask)
                             mask = ~mask;
                         score -= bishop_pawns_penalty[0] * count(pawns[0] & mask);
                         score -= bishop_pawns_penalty[1] * count(pawns[1] & mask);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -575,8 +575,8 @@ const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
                         u64 mask = 0xAA55AA55AA55AA55ULL;
                         if (piece_bb & ~mask)
                             mask = ~mask;
-                        score -= bishop_pawns_penalty[0] * count(pawns[0] & mask);
-                        score -= bishop_pawns_penalty[1] * count(pawns[1] & mask);
+                        for (i32 i = 0; i < 2; ++i)
+                            score -= bishop_pawns_penalty[i] * count(pawns[i] & mask);
                     }
 
                     if (p == King && piece_bb & 0xC3D7) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -423,50 +423,51 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {139, 450, 453, 849, 1685, 0, 0};
-const i32 material[] = {S(95, 139), S(339, 450), S(348, 453), S(461, 849), S(832, 1685), 0};
+const i32 max_material[] = {141, 427, 475, 830, 1652, 0, 0};
+const i32 material[] = {S(97, 141), S(343, 427), S(394, 475), S(471, 830), S(849, 1652), 0};
 const i32 pst_rank[] = {
     0,         S(-3, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
-    S(-3, -5), S(-1, -3), S(0, -1),  S(2, 2),   S(3, 4),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
-    S(-1, -2), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-8, 2),   // Bishop
-    S(0, -3),  S(-1, -3), S(-2, -2), S(-3, 1),  S(0, 2),  S(2, 2), S(1, 3),  S(3, 1),    // Rook
-    S(2, -11), S(2, -9),  S(1, -4),  S(-1, 1),  S(-1, 5), S(0, 5), S(-3, 7), S(-1, 5),   // Queen
-    S(-1, -5), S(1, -2),  0,         S(-2, 2),  S(0, 4),  S(6, 4), S(4, 2),  S(3, -4)    // King
+    S(-2, -4), S(-1, -3), S(0, -1),  S(2, 2),   S(3, 3),  S(6, 1), S(4, 0),  S(-12, 2),  // Knight
+    S(-1, -2), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-9, 2),   // Bishop
+    S(0, -3),  S(-1, -3), S(-2, -2), S(-3, 0),  S(0, 2),  S(2, 2), S(1, 3),  S(3, 1),    // Rook
+    S(2, -11), S(3, -9),  S(1, -4),  S(0, 1),   S(-1, 5), S(0, 5), S(-3, 7), S(-1, 5),   // Queen
+    S(-1, -5), S(1, -2),  0,         S(-2, 2),  S(0, 4),  S(6, 4), S(3, 3),  S(2, -4)    // King
 };
 const i32 pst_file[] = {
     S(-1, 1),  S(-2, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, -1),  // Pawn
-    S(-5, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  S(1, 0),  S(-1, -3),  // Knight
-    S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(1, 1),  S(-1, 1), S(2, 0),  S(0, -1),   // Bishop
+    S(-5, -2), S(-2, -1), S(0, 1),  S(2, 2),  S(2, 2),  S(2, 0),  S(1, 0),  S(-1, -3),  // Knight
+    S(-2, -1), 0,         S(1, 0),  S(0, 1),  S(1, 1),  S(-1, 1), S(2, -1), S(0, -1),   // Bishop
     S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(2, -1), S(1, 0),  S(1, 0),  S(-2, 0),   // Rook
     S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(2, -1),   // Queen
-    S(-3, -5), S(2, -2),  S(-1, 1), S(-2, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
+    S(-3, -5), S(3, -2),  S(-1, 1), S(-2, 2), S(-3, 2), S(-1, 1), S(2, -1), S(-1, -5)   // King
 };
 const i32 open_files[] = {
     // Semi open files
-    S(2, 4),
-    S(-5, 20),
-    S(18, 15),
+    S(2, 6),
+    S(-5, 18),
+    S(18, 16),
     S(3, 18),
-    S(-22, 10),
+    S(-23, 10),
     // Open files
-    S(-3, -12),
-    S(-11, -1),
-    S(46, 0),
-    S(-14, 37),
-    S(-60, 1),
+    S(-2, -10),
+    S(-11, -4),
+    S(47, 0),
+    S(-14, 38),
+    S(-59, 1),
 };
-const i32 mobilities[] = {S(9, 5), S(8, 7), S(3, 4), S(4, 2), S(-5, 0)};
-const i32 king_attacks[] = {S(10, -5), S(18, -5), S(26, -10), S(19, 3), 0};
-const i32 pawn_protection[] = {S(22, 14), S(2, 15), S(7, 17), S(8, 10), S(-5, 20), S(-31, 25)};
-const i32 pawn_threat_penalty[] = {S(-4, 1), S(21, 1), S(12, 5), S(11, 17), S(9, 17), S(6, 5)};
-const i32 passers[] = {S(4, 14), S(35, 50), S(68, 124), S(220, 207)};
-const i32 pawn_passed_protected = S(11, 20);
+const i32 mobilities[] = {S(9, 7), S(7, 5), S(3, 4), S(4, 2), S(-5, -1)};
+const i32 king_attacks[] = {S(11, -5), S(19, -5), S(28, -10), S(21, 2), 0};
+const i32 pawn_protection[] = {S(22, 14), S(2, 12), S(7, 25), S(7, 9), S(-5, 18), S(-32, 25)};
+const i32 pawn_threat_penalty[] = {S(-4, 1), S(22, 3), S(10, 3), S(11, 17), S(10, 17), S(7, 5)};
+const i32 passers[] = {S(2, 13), S(32, 50), S(63, 124), S(200, 250)};
+const i32 pawn_passed_protected = S(11, 19);
 const i32 pawn_doubled_penalty = S(11, 37);
-const i32 pawn_phalanx = S(12, 11);
-const i32 pawn_passed_blocked_penalty[] = {S(9, 14), S(-7, 43), S(-9, 85), S(4, 97)};
+const i32 pawn_phalanx = S(12, 12);
+const i32 pawn_passed_blocked_penalty[] = {S(10, 11), S(-5, 39), S(-8, 82), S(-9, 158)};
 const i32 pawn_passed_king_distance[] = {S(1, -6), S(-4, 11)};
-const i32 bishop_pair = S(32, 72);
-const i32 king_shield[] = {S(36, -12), S(27, -7)};
+const i32 bishop_pair = S(35, 71);
+const i32 bishop_pawns_penalty[] = {S(7, 14), S(6, 1)};
+const i32 king_shield[] = {S(36, -12), S(28, -7)};
 const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
 
 [[nodiscard]] i32 eval(Position &pos) {
@@ -568,6 +569,15 @@ const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
                     // Open or semi-open files
                     if (!(0x101010101010101ull << file & pawns[0]))
                         score += open_files[!(0x101010101010101ull << file & pawns[1]) * 5 + p - 1];
+
+                    // Pawns on bishop colored squares
+                    if (p == Bishop) {
+                        u64 mask = 0xAA55AA55AA55AA55UL;
+                        if (!(piece_bb & mask))
+                            mask = ~mask;
+                        score -= bishop_pawns_penalty[0] * count(pawns[0] & mask);
+                        score -= bishop_pawns_penalty[1] * count(pawns[1] & mask);
+                    }
 
                     if (p == King && piece_bb & 0xC3D7) {
                         // C3D7 = Reasonable king squares

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -572,7 +572,7 @@ const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
 
                     // Pawns on bishop coloured squares
                     if (p == Bishop) {
-                        u64 mask = 0xAA55AA55AA55AA55ULL;
+                        u64 mask = 0xAA55AA55AA55AA55ull;
                         if (piece_bb & ~mask)
                             mask = ~mask;
                         for (i32 i = 0; i < 2; ++i)


### PR DESCRIPTION
STC:
```
Elo   | 6.61 +- 5.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10142 W: 3008 L: 2815 D: 4319
Penta | [293, 1166, 2025, 1229, 358]
```
http://chess.grantnet.us/test/34401/

LTC:
```
Elo   | 12.17 +- 7.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4370 W: 1199 L: 1046 D: 2125
Penta | [79, 502, 905, 585, 114]
```
http://chess.grantnet.us/test/34402/

+54 bytes