### PR TITLE
TT entry size 16 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,986 bytes
+3,985 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,970 bytes
+3,989 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,989 bytes
+3,988 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,999 bytes
+3,986 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,988 bytes
+4,003 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,003 bytes
+3,999 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,9 +70,9 @@ struct [[nodiscard]] Position {
 };
 
 struct Move {
-    i32 from = 0;
-    i32 to = 0;
-    i32 promo = 0;
+    int8_t from = 0;
+    int8_t to = 0;
+    int8_t promo = 0;
 };
 
 const Move no_move{};
@@ -294,15 +294,16 @@ auto makemove(Position &pos, const Move &move) {
 
 void generate_pawn_moves(Move *const movelist, i32 &num_moves, u64 to_mask, const i32 offset) {
     while (to_mask) {
-        const i32 to = lsb(to_mask);
+        const int8_t to = lsb(to_mask);
+        const int8_t from = to + offset;
         to_mask &= to_mask - 1;
         if (to >= 56) {
-            movelist[num_moves++] = Move{to + offset, to, Queen};
-            movelist[num_moves++] = Move{to + offset, to, Rook};
-            movelist[num_moves++] = Move{to + offset, to, Bishop};
-            movelist[num_moves++] = Move{to + offset, to, Knight};
+            movelist[num_moves++] = Move{from, to, Queen};
+            movelist[num_moves++] = Move{from, to, Rook};
+            movelist[num_moves++] = Move{from, to, Bishop};
+            movelist[num_moves++] = Move{from, to, Knight};
         } else
-            movelist[num_moves++] = Move{to + offset, to, None};
+            movelist[num_moves++] = Move{from, to, None};
     }
 }
 
@@ -315,11 +316,11 @@ void generate_piece_moves(Move *const movelist,
                           F f) {
     u64 copy = pos.colour[0] & pos.pieces[piece];
     while (copy) {
-        const i32 fr = lsb(copy);
+        const int8_t fr = lsb(copy);
         copy &= copy - 1;
         u64 moves = f(fr, pos.colour[0] | pos.colour[1]) & to_mask;
         while (moves) {
-            const i32 to = lsb(moves);
+            const int8_t to = lsb(moves);
             moves &= moves - 1;
             movelist[num_moves++] = Move{fr, to, None};
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,9 +70,9 @@ struct [[nodiscard]] Position {
 };
 
 struct Move {
-    int8_t from = 0;
-    int8_t to = 0;
-    int8_t promo = 0;
+    uint8_t from = 0;
+    uint8_t to = 0;
+    uint8_t promo = 0;
 };
 
 const Move no_move{};
@@ -294,8 +294,8 @@ auto makemove(Position &pos, const Move &move) {
 
 void generate_pawn_moves(Move *const movelist, i32 &num_moves, u64 to_mask, const i32 offset) {
     while (to_mask) {
-        const int8_t to = lsb(to_mask);
-        const int8_t from = to + offset;
+        const uint8_t to = lsb(to_mask);
+        const uint8_t from = to + offset;
         to_mask &= to_mask - 1;
         if (to >= 56) {
             movelist[num_moves++] = Move{from, to, Queen};
@@ -316,11 +316,11 @@ void generate_piece_moves(Move *const movelist,
                           F f) {
     u64 copy = pos.colour[0] & pos.pieces[piece];
     while (copy) {
-        const int8_t fr = lsb(copy);
+        const uint8_t fr = lsb(copy);
         copy &= copy - 1;
         u64 moves = f(fr, pos.colour[0] | pos.colour[1]) & to_mask;
         while (moves) {
-            const int8_t to = lsb(moves);
+            const uint8_t to = lsb(moves);
             moves &= moves - 1;
             movelist[num_moves++] = Move{fr, to, None};
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,7 +95,7 @@ enum
     Exact
 };
 
-struct [[nodiscard]] TT_Entry {
+struct [[nodiscard]] TTEntry {
     u64 key;
     Move move;
     u8 flag;
@@ -109,7 +109,7 @@ u64 keys[848];
 u64 num_tt_entries = 64ULL << 16;  // The first value is the size in megabytes
 i32 thread_count = 1;
 
-vector<TT_Entry> transposition_table;
+vector<TTEntry> transposition_table;
 
 [[nodiscard]] u64 flip(const u64 bb) {
     return __builtin_bswap64(bb);
@@ -588,7 +588,7 @@ i32 alphabeta(Position &pos,
     }
 
     // TT Probing
-    TT_Entry &tt_entry = transposition_table[tt_key % num_tt_entries];
+    TTEntry &tt_entry = transposition_table[tt_key % num_tt_entries];
     Move tt_move{};
     if (tt_entry.key == tt_key) {
         tt_move = tt_entry.move;
@@ -827,7 +827,7 @@ void print_pv(const Position &pos, const Move move, vector<u64> &hash_history) {
 
     // Probe the TT in the resulting position
     const u64 tt_key = get_hash(npos);
-    const TT_Entry &tt_entry = transposition_table[tt_key % num_tt_entries];
+    const TTEntry &tt_entry = transposition_table[tt_key % num_tt_entries];
 
     // Only continue if the move was valid and comes from a PV search
     if (tt_entry.key != tt_key || tt_entry.move == no_move || tt_entry.flag != 2)
@@ -1091,7 +1091,8 @@ i32 main(
     cout << "id author kz04px\n";
     // minify enable filter delete
     cout << "option name Threads type spin default " << thread_count << " min 1 max 256\n";
-    cout << "option name Hash type spin default " << (num_tt_entries >> 16) << " min 1 max 65536\n";
+    cout << "option name Hash type spin default " << (num_tt_entries * sizeof(TTEntry) / (1024 * 1024))
+         << " min 1 max 65536\n";
     // minify disable filter delete
     cout << "uciok\n";
 
@@ -1107,7 +1108,7 @@ i32 main(
         )
             break;
         else if (word == "ucinewgame")
-            memset(transposition_table.data(), 0, sizeof(TT_Entry) * transposition_table.size());
+            memset(transposition_table.data(), 0, sizeof(TTEntry) * transposition_table.size());
         else if (word == "isready")
             cout << "readyok\n";
         // minify enable filter delete
@@ -1122,7 +1123,7 @@ i32 main(
                 i32 megabytes = 1;
                 cin >> word;
                 cin >> megabytes;
-                num_tt_entries = static_cast<u64>(min(max(megabytes, 1), 65536)) * 1024 * 1024 / sizeof(TT_Entry);
+                num_tt_entries = static_cast<u64>(min(max(megabytes, 1), 65536)) * 1024 * 1024 / sizeof(TTEntry);
                 transposition_table.clear();
                 transposition_table.resize(num_tt_entries);
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1016,8 +1016,6 @@ i32 main(
 ) {
     setbuf(stdout, 0);
 
-    sizeof(TT_Entry);
-
     // Generate used attack masks
     for (i32 i = 0; i < 64; ++i)
         diag_mask[i] = ray(i, 0, ne) | ray(i, 0, sw);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -795,7 +795,7 @@ i32 alphabeta(Position &pos,
         return in_check ? ply - mate_score : 0;
 
     // Save to TT
-    tt_entry = {tt_key, best_move, tt_flag, int16_t(best_score), int16_t(in_qsearch ? 0 : depth)};
+    tt_entry = {tt_key, best_move, tt_flag, int16_t(best_score), int16_t(!in_qsearch * depth)};
 
     return best_score;
 }
@@ -1091,7 +1091,8 @@ i32 main(
     cout << "id author kz04px\n";
     // minify enable filter delete
     cout << "option name Threads type spin default " << thread_count << " min 1 max 256\n";
-    cout << "option name Hash type spin default " << num_tt_entries * sizeof(TTEntry) / (1024 * 1024) << " min 1 max 65536\n";
+    cout << "option name Hash type spin default " << num_tt_entries * sizeof(TTEntry) / (1024 * 1024)
+         << " min 1 max 65536\n";
     // minify disable filter delete
     cout << "uciok\n";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 
 using namespace std;
 
+using u8 = uint8_t;
 using i32 = int;
 using u64 = uint64_t;
 
@@ -70,9 +71,9 @@ struct [[nodiscard]] Position {
 };
 
 struct Move {
-    uint8_t from = 0;
-    uint8_t to = 0;
-    uint8_t promo = 0;
+    u8 from = 0;
+    u8 to = 0;
+    u8 promo = 0;
 };
 
 const Move no_move{};
@@ -97,7 +98,7 @@ enum
 struct [[nodiscard]] TT_Entry {
     u64 key;
     Move move;
-    uint8_t flag;
+    u8 flag;
     int16_t score;
     int16_t depth;
 };
@@ -294,8 +295,8 @@ auto makemove(Position &pos, const Move &move) {
 
 void generate_pawn_moves(Move *const movelist, i32 &num_moves, u64 to_mask, const i32 offset) {
     while (to_mask) {
-        const uint8_t to = lsb(to_mask);
-        const uint8_t from = to + offset;
+        const u8 to = lsb(to_mask);
+        const u8 from = to + offset;
         to_mask &= to_mask - 1;
         if (to >= 56) {
             movelist[num_moves++] = Move{from, to, Queen};
@@ -316,11 +317,11 @@ void generate_piece_moves(Move *const movelist,
                           F f) {
     u64 copy = pos.colour[0] & pos.pieces[piece];
     while (copy) {
-        const uint8_t fr = lsb(copy);
+        const u8 fr = lsb(copy);
         copy &= copy - 1;
         u64 moves = f(fr, pos.colour[0] | pos.colour[1]) & to_mask;
         while (moves) {
-            const uint8_t to = lsb(moves);
+            const u8 to = lsb(moves);
             moves &= moves - 1;
             movelist[num_moves++] = Move{fr, to, None};
         }
@@ -648,7 +649,7 @@ i32 alphabeta(Position &pos,
     }
 
     hash_history.emplace_back(tt_key);
-    uint8_t tt_flag = Upper;
+    u8 tt_flag = Upper;
 
     i32 num_moves_evaluated = 0;
     i32 num_quiets_evaluated = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1091,8 +1091,7 @@ i32 main(
     cout << "id author kz04px\n";
     // minify enable filter delete
     cout << "option name Threads type spin default " << thread_count << " min 1 max 256\n";
-    cout << "option name Hash type spin default " << (num_tt_entries * sizeof(TTEntry) / (1024 * 1024))
-         << " min 1 max 65536\n";
+    cout << "option name Hash type spin default " << num_tt_entries * sizeof(TTEntry) / (1024 * 1024) << " min 1 max 65536\n";
     // minify disable filter delete
     cout << "uciok\n";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1091,7 +1091,7 @@ i32 main(
     cout << "id author kz04px\n";
     // minify enable filter delete
     cout << "option name Threads type spin default " << thread_count << " min 1 max 256\n";
-    cout << "option name Hash type spin default " << (num_tt_entries >> 15) << " min 1 max 65536\n";
+    cout << "option name Hash type spin default " << (num_tt_entries >> 19) << " min 1 max 65536\n";
     // minify disable filter delete
     cout << "uciok\n";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,8 +36,8 @@ using i32 = int;
 using u64 = uint64_t;
 
 // Constants
-const i32 mate_score = 1 << 15;
-const i32 inf = 1 << 16;
+const i32 mate_score = 30000;
+const i32 inf = 32000;
 
 enum
 {
@@ -97,15 +97,15 @@ enum
 struct [[nodiscard]] TT_Entry {
     u64 key;
     Move move;
-    i32 score;
-    i32 depth;
-    uint16_t flag;
+    uint8_t flag;
+    int16_t score;
+    int16_t depth;
 };
 
 u64 keys[848];
 
 // Engine options
-u64 num_tt_entries = 64ULL << 15;  // The first value is the size in megabytes
+u64 num_tt_entries = 64ULL << 16;  // The first value is the size in megabytes
 i32 thread_count = 1;
 
 vector<TT_Entry> transposition_table;
@@ -648,7 +648,7 @@ i32 alphabeta(Position &pos,
     }
 
     hash_history.emplace_back(tt_key);
-    uint16_t tt_flag = Upper;
+    uint8_t tt_flag = Upper;
 
     i32 num_moves_evaluated = 0;
     i32 num_quiets_evaluated = 0;
@@ -794,7 +794,7 @@ i32 alphabeta(Position &pos,
         return in_check ? ply - mate_score : 0;
 
     // Save to TT
-    tt_entry = {tt_key, best_move, best_score, in_qsearch ? 0 : depth, tt_flag};
+    tt_entry = {tt_key, best_move, tt_flag, int16_t(best_score), int16_t(in_qsearch ? 0 : depth)};
 
     return best_score;
 }
@@ -1015,6 +1015,8 @@ i32 main(
     // minify disable filter delete
 ) {
     setbuf(stdout, 0);
+
+    sizeof(TT_Entry);
 
     // Generate used attack masks
     for (i32 i = 0; i < 64; ++i)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1091,7 +1091,7 @@ i32 main(
     cout << "id author kz04px\n";
     // minify enable filter delete
     cout << "option name Threads type spin default " << thread_count << " min 1 max 256\n";
-    cout << "option name Hash type spin default " << (num_tt_entries >> 19) << " min 1 max 65536\n";
+    cout << "option name Hash type spin default " << (num_tt_entries >> 16) << " min 1 max 65536\n";
     // minify disable filter delete
     cout << "uciok\n";
 


### PR DESCRIPTION
I did an additional patch with type aliasing which made size a lot smaller than what it was in the original test.

STC:
```
Elo   | 17.04 +- 9.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3224 W: 1015 L: 857 D: 1352
Penta | [77, 346, 650, 420, 119]
```
http://chess.grantnet.us/test/34461/

LTC:
```
Elo   | 15.25 +- 8.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3260 W: 890 L: 747 D: 1623
Penta | [53, 351, 701, 450, 75]
```
http://chess.grantnet.us/test/34462/

+15 bytes