### PR TITLE
Fix memory usage when reducing TT size

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1124,8 +1124,8 @@ i32 main(
                 cin >> word;
                 cin >> megabytes;
                 num_tt_entries = static_cast<u64>(min(max(megabytes, 1), 65536)) * 1024 * 1024 / sizeof(TTEntry);
-                transposition_table.clear();
                 transposition_table.resize(num_tt_entries);
+                transposition_table.clear();
                 transposition_table.shrink_to_fit();
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1126,6 +1126,7 @@ i32 main(
                 num_tt_entries = static_cast<u64>(min(max(megabytes, 1), 65536)) * 1024 * 1024 / sizeof(TTEntry);
                 transposition_table.clear();
                 transposition_table.resize(num_tt_entries);
+                transposition_table.shrink_to_fit();
             }
         }
         // minify disable filter delete


### PR DESCRIPTION
When reducing `Hash` to a smaller one, it would then use less entries, but the memory usage would stay high. This included reducing to anything smaller than the default `64`. This fixes that.