### PR TITLE
Persistent history heuristic table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,987 bytes
+4,024 bytes
 ```
 
 ---


### PR DESCRIPTION
STC:
```
Elo   | 10.24 +- 6.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5636 W: 1645 L: 1479 D: 2512
Penta | [142, 590, 1204, 724, 158]
```
http://chess.grantnet.us/test/34512/

LTC:
```
Elo   | 5.32 +- 4.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11432 W: 2963 L: 2788 D: 5681
Penta | [168, 1322, 2601, 1417, 208]
```
http://chess.grantnet.us/test/34513/

+37 bytes