### PR TITLE
Tweak usage of histories in LMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,979 bytes
+3,983 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -805,7 +805,7 @@ i32 alphabeta(Position &pos,
             // Late move reduction
             i32 reduction = depth > 2 && num_moves_evaluated > 4 && !gain
                                 ? num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
-                                      min(max(hh_table[pos.flipped][move.from][move.to], -1), 1)
+                                      min(max(hh_table[pos.flipped][move.from][move.to] / 128, -2), 2)
                                 : 0;
 
         zero_window:


### PR DESCRIPTION
Passed STC
Elo   | 6.98 +- 5.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.17 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9662 W: 2723 L: 2529 D: 4410
Penta | [228, 1113, 1994, 1229, 267]
http://chess.grantnet.us/test/34554/

Passed LTC
Elo   | 4.50 +- 3.91 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15058 W: 3836 L: 3641 D: 7581
Penta | [254, 1787, 3263, 1960, 265]
http://chess.grantnet.us/test/34556/

+4 bytes
Bench: 4990678