### PR TITLE
Capture history2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,983 bytes
+4,003 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -745,10 +745,8 @@ i32 alphabeta(Position &pos,
         if (i == !(no_move == tt_move))
             for (i32 j = 0; j < num_moves; ++j) {
                 const i32 gain = max_material[moves[j].promo] + max_material[piece_on(pos, moves[j].to)];
-                move_scores[j] =
-                    hh_table[pos.flipped][!gain][moves[j].from][moves[j].to] + (gain ? gain * 1024
-                                                                                : moves[j] == stack[ply].killer ? 1024
-                                                                                                                : 0);
+                move_scores[j] = hh_table[pos.flipped][!gain][moves[j].from][moves[j].to] +
+                                 (gain || moves[j] == stack[ply].killer ? 2048 : 0) + gain;
             }
 
         // Find best move remaining

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -855,12 +855,12 @@ i32 alphabeta(Position &pos,
                 hh_table[pos.flipped][!gain][move.from][move.to] +=
                     depth * depth - depth * depth * hh_table[pos.flipped][!gain][move.from][move.to] / 512;
                 for (i32 j = 0; j < num_moves_evaluated - 1; ++j) {
-                    const i32 prev_gain =
+                    const i32 previous_gain =
                         max_material[moves_evaluated[j].promo] + max_material[piece_on(pos, moves_evaluated[j].to)];
-                    hh_table[pos.flipped][!prev_gain][moves_evaluated[j].from][moves_evaluated[j].to] -=
+                    hh_table[pos.flipped][!previous_gain][moves_evaluated[j].from][moves_evaluated[j].to] -=
                         depth * depth +
                         depth * depth *
-                            hh_table[pos.flipped][!prev_gain][moves_evaluated[j].from][moves_evaluated[j].to] / 512;
+                            hh_table[pos.flipped][!previous_gain][moves_evaluated[j].from][moves_evaluated[j].to] / 512;
                 }
                 if (!gain)
                     stack[ply].killer = move;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,7 @@ const Move no_move{};
 
 struct [[nodiscard]] Stack {
     Move moves[256];
-    Move quiets_evaluated[256];
+    Move moves_evaluated[256];
     i32 move_scores[256];
     Move move;
     Move killer;
@@ -638,7 +638,7 @@ i32 alphabeta(Position &pos,
               Stack *const stack,
               i32 &stop,
               vector<u64> &hash_history,
-              i32 (&hh_table)[2][64][64],
+              i32 (&hh_table)[2][2][64][64],
               const i32 do_null = true) {
     assert(alpha < beta);
     assert(ply >= 0);
@@ -736,7 +736,7 @@ i32 alphabeta(Position &pos,
 
     auto &moves = stack[ply].moves;
     auto &move_scores = stack[ply].move_scores;
-    auto &quiets_evaluated = stack[ply].quiets_evaluated;
+    auto &moves_evaluated = stack[ply].moves_evaluated;
     const i32 num_moves = movegen(pos, moves, in_qsearch);
 
     for (i32 i = 0; i < num_moves; ++i) {
@@ -745,9 +745,10 @@ i32 alphabeta(Position &pos,
         if (i == !(no_move == tt_move))
             for (i32 j = 0; j < num_moves; ++j) {
                 const i32 gain = max_material[moves[j].promo] + max_material[piece_on(pos, moves[j].to)];
-                move_scores[j] = gain                            ? gain + 1025
-                                 : moves[j] == stack[ply].killer ? 1024
-                                                                 : hh_table[pos.flipped][moves[j].from][moves[j].to];
+                move_scores[j] =
+                    hh_table[pos.flipped][!gain][moves[j].from][moves[j].to] + (gain ? gain * 1024
+                                                                                : moves[j] == stack[ply].killer ? 1024
+                                                                                                                : 0);
             }
 
         // Find best move remaining
@@ -805,7 +806,7 @@ i32 alphabeta(Position &pos,
             // Late move reduction
             i32 reduction = depth > 2 && num_moves_evaluated > 4 && !gain
                                 ? num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
-                                      min(max(hh_table[pos.flipped][move.from][move.to] / 128, -2), 2)
+                                      min(max(hh_table[pos.flipped][1][move.from][move.to] / 128, -2), 2)
                                 : 0;
 
         zero_window:
@@ -838,9 +839,9 @@ i32 alphabeta(Position &pos,
             return 0;
         }
 
-        num_moves_evaluated++;
+        moves_evaluated[num_moves_evaluated++] = move;
         if (!gain)
-            quiets_evaluated[num_quiets_evaluated++] = move;
+            num_quiets_evaluated++;
 
         if (score > best_score)
             best_score = score;
@@ -852,16 +853,19 @@ i32 alphabeta(Position &pos,
             stack[ply].move = move;
             if (score >= beta) {
                 tt_flag = Lower;
-                if (!gain) {
-                    hh_table[pos.flipped][move.from][move.to] +=
-                        depth * depth - depth * depth * hh_table[pos.flipped][move.from][move.to] / 512;
-                    for (i32 j = 0; j < num_quiets_evaluated - 1; ++j)
-                        hh_table[pos.flipped][quiets_evaluated[j].from][quiets_evaluated[j].to] -=
-                            depth * depth +
-                            depth * depth * hh_table[pos.flipped][quiets_evaluated[j].from][quiets_evaluated[j].to] /
-                                512;
-                    stack[ply].killer = move;
+
+                hh_table[pos.flipped][!gain][move.from][move.to] +=
+                    depth * depth - depth * depth * hh_table[pos.flipped][!gain][move.from][move.to] / 512;
+                for (i32 j = 0; j < num_moves_evaluated - 1; ++j) {
+                    const i32 prev_gain =
+                        max_material[moves_evaluated[j].promo] + max_material[piece_on(pos, moves_evaluated[j].to)];
+                    hh_table[pos.flipped][!prev_gain][moves_evaluated[j].from][moves_evaluated[j].to] -=
+                        depth * depth +
+                        depth * depth *
+                            hh_table[pos.flipped][!prev_gain][moves_evaluated[j].from][moves_evaluated[j].to] / 512;
                 }
+                if (!gain)
+                    stack[ply].killer = move;
                 break;
             }
         }
@@ -928,7 +932,7 @@ void print_pv(const Position &pos, const Move move, vector<u64> &hash_history) {
 auto iteratively_deepen(Position &pos,
                         i32 &stop,
                         vector<u64> &hash_history,
-                        i32 (&hh_table)[2][64][64],
+                        i32 (&hh_table)[2][2][64][64],
                         // minify enable filter delete
                         i32 thread_id,
                         const i32 bench_depth,
@@ -1109,7 +1113,7 @@ i32 main(
 
     Position pos;
     vector<u64> hash_history;
-    i32 hh_table[2][64][64] = {};
+    i32 hh_table[2][2][64][64] = {};
 
     // minify enable filter delete
     // OpenBench compliance


### PR DESCRIPTION
STC:
```
Elo   | 11.13 +- 6.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5214 W: 1503 L: 1336 D: 2375
Penta | [133, 582, 1035, 699, 158]
```
http://chess.grantnet.us/test/34589/

LTC:
```
Elo   | 13.72 +- 7.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3700 W: 987 L: 841 D: 1872
Penta | [48, 431, 781, 507, 83]
```
http://chess.grantnet.us/test/34591/

+20 bytes