### PR TITLE
Tweak history usage in LMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,964 bytes
+3,969 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -801,8 +801,9 @@ i32 alphabeta(Position &pos,
         else {
             // Late move reduction
             i32 reduction = depth > 2 && num_moves_evaluated > 4 && !gain
-                                ? num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
-                                      min(max(hh_table[pos.flipped][move.from][move.to], -1), 1)
+                                ? max(num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
+                                          min(max(hh_table[pos.flipped][move.from][move.to] / 128, -2), 2),
+                                      -1)
                                 : 0;
 
         zero_window:


### PR DESCRIPTION
Also caps it at reduction -1 to disallow double extensions.

Passed STC:
Elo   | 5.14 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14072 W: 3914 L: 3706 D: 6452
Penta | [349, 1661, 2860, 1765, 401]
http://chess.grantnet.us/test/34561/

Passed LTC:
Elo   | 3.44 +- 3.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23404 W: 5912 L: 5680 D: 11812
Penta | [388, 2743, 5253, 2885, 433]
http://chess.grantnet.us/test/34562/

Bench: 5065589
+5 bytes