### PR TITLE
Capture history

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,969 bytes
+3,989 bytes
 ```
 
 ---


### PR DESCRIPTION
STC:
```
Elo   | 13.39 +- 7.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4180 W: 1218 L: 1057 D: 1905
Penta | [90, 464, 851, 565, 120]
```
http://chess.grantnet.us/test/34607/

LTC:
```
Elo   | 10.25 +- 6.62 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5154 W: 1334 L: 1182 D: 2638
Penta | [90, 565, 1130, 687, 105]
```
http://chess.grantnet.us/test/34608/

Previous tests for the same changes vs. a similar base branch:
STC:
```
Elo   | 11.13 +- 6.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5214 W: 1503 L: 1336 D: 2375
Penta | [133, 582, 1035, 699, 158]
```
http://chess.grantnet.us/test/34589/

LTC:
```
Elo   | 13.72 +- 7.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3700 W: 987 L: 841 D: 1872
Penta | [48, 431, 781, 507, 83]
```
http://chess.grantnet.us/test/34591/

+20 bytes