### PR TITLE
LMR for captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,989 bytes
+3,982 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,986 bytes
+3,982 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,982 bytes
+3,986 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -799,11 +799,12 @@ i32 alphabeta(Position &pos,
                                hh_table);
         else {
             // Late move reduction
-            i32 reduction = depth > 2 && num_moves_evaluated > 4
-                                ? max(num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
-                                          min(max(hh_table[pos.flipped][!gain][move.from][move.to] / 128, -2), 2),
-                                      0)
-                                : 0;
+            i32 reduction =
+                depth > 2 && num_moves_evaluated > 4
+                    ? max(num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
+                              min(max(hh_table[pos.flipped][!gain][move.from][move.to] / 128, -2), 2) + !gain,
+                          0)
+                    : 0;
 
         zero_window:
             score = -alphabeta(npos,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -806,6 +806,7 @@ i32 alphabeta(Position &pos,
                                 : 0;
 
         zero_window:
+            assert(reduction >= 0);
             score = -alphabeta(npos,
                                -alpha - 1,
                                -alpha,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -799,10 +799,10 @@ i32 alphabeta(Position &pos,
                                hh_table);
         else {
             // Late move reduction
-            i32 reduction = depth > 2 && num_moves_evaluated > 4 && !gain
+            i32 reduction = depth > 2 && num_moves_evaluated > 4
                                 ? max(num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
-                                          min(max(hh_table[pos.flipped][1][move.from][move.to] / 128, -2), 2),
-                                      -1)
+                                          min(max(hh_table[pos.flipped][!gain][move.from][move.to] / 128, -2), 2),
+                                      0)
                                 : 0;
 
         zero_window:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -799,12 +799,11 @@ i32 alphabeta(Position &pos,
                                hh_table);
         else {
             // Late move reduction
-            i32 reduction =
-                depth > 2 && num_moves_evaluated > 4
-                    ? max(num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
-                              min(max(hh_table[pos.flipped][!gain][move.from][move.to] / 128, -2), 2) + !gain,
-                          0)
-                    : 0;
+            i32 reduction = depth > 2 && num_moves_evaluated > 4
+                                ? max(num_moves_evaluated / 13 + depth / 15 + (alpha == beta - 1) + !improving -
+                                          min(max(hh_table[pos.flipped][!gain][move.from][move.to] / 128, -2), 2),
+                                      0)
+                                : 0;
 
         zero_window:
             score = -alphabeta(npos,


### PR DESCRIPTION
STC:
```
Elo   | 3.18 +- 2.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 32048 W: 8763 L: 8470 D: 14815
Penta | [784, 3841, 6560, 3976, 863]
```
http://chess.grantnet.us/test/34619/

LTC:
```
Elo   | 5.54 +- 4.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 3.00]
Games | N: 11232 W: 2850 L: 2671 D: 5711
Penta | [182, 1317, 2466, 1442, 209]
```
http://chess.grantnet.us/test/34626/

Bench: 5129249
-6 bytes