### PR TITLE
Quadratic pawn endgame scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,974 bytes
+3,982 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -423,50 +423,50 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {139, 450, 453, 849, 1685, 0, 0};
-const i32 material[] = {S(95, 139), S(339, 450), S(348, 453), S(461, 849), S(832, 1685), 0};
+const i32 max_material[] = {137, 443, 446, 837, 1693, 0, 0};
+const i32 material[] = {S(93, 137), S(325, 443), S(334, 446), S(440, 837), S(750, 1693), 0};
 const i32 pst_rank[] = {
     0,         S(-3, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
-    S(-3, -5), S(-1, -3), S(0, -1),  S(2, 2),   S(3, 4),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
-    S(-1, -2), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-8, 2),   // Bishop
-    S(0, -3),  S(-1, -3), S(-2, -2), S(-3, 1),  S(0, 2),  S(2, 2), S(1, 3),  S(3, 1),    // Rook
-    S(2, -11), S(2, -9),  S(1, -4),  S(-1, 1),  S(-1, 5), S(0, 5), S(-3, 7), S(-1, 5),   // Queen
-    S(-1, -5), S(1, -2),  0,         S(-2, 2),  S(0, 4),  S(6, 4), S(4, 2),  S(3, -4)    // King
+    S(-3, -4), S(-1, -3), S(0, -1),  S(2, 2),   S(3, 3),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
+    S(-1, -1), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-8, 2),   // Bishop
+    S(0, -3),  S(-1, -3), S(-2, -2), S(-3, 0),  S(0, 2),  S(2, 2), S(1, 3),  S(3, 1),    // Rook
+    S(2, -11), S(3, -8),  S(1, -4),  S(0, 1),   S(-1, 5), S(0, 5), S(-3, 6), S(-1, 5),   // Queen
+    S(-1, -5), S(1, -2),  0,         S(-2, 2),  S(0, 4),  S(5, 4), S(2, 3),  S(1, -3)    // King
 };
 const i32 pst_file[] = {
     S(-1, 1),  S(-2, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, -1),  // Pawn
     S(-5, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  S(1, 0),  S(-1, -3),  // Knight
     S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(1, 1),  S(-1, 1), S(2, 0),  S(0, -1),   // Bishop
     S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(2, -1), S(1, 0),  S(1, 0),  S(-2, 0),   // Rook
-    S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(2, -1),   // Queen
-    S(-3, -5), S(2, -2),  S(-1, 1), S(-2, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
+    S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(1, -1),   // Queen
+    S(-2, -5), S(2, -2),  S(-1, 1), S(-2, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
 };
 const i32 open_files[] = {
     // Semi open files
-    S(2, 4),
-    S(-5, 20),
+    S(1, 5),
+    S(-5, 19),
     S(18, 15),
     S(3, 18),
-    S(-22, 10),
+    S(-21, 9),
     // Open files
-    S(-3, -12),
-    S(-11, -1),
+    S(-3, -11),
+    S(-11, 0),
     S(46, 0),
-    S(-14, 37),
-    S(-60, 1),
+    S(-15, 37),
+    S(-59, 1),
 };
 const i32 mobilities[] = {S(9, 5), S(8, 7), S(3, 4), S(4, 2), S(-5, 0)};
-const i32 king_attacks[] = {S(10, -5), S(18, -5), S(26, -10), S(19, 3), 0};
-const i32 pawn_protection[] = {S(22, 14), S(2, 15), S(7, 17), S(8, 10), S(-5, 20), S(-31, 25)};
-const i32 pawn_threat_penalty[] = {S(-4, 1), S(21, 1), S(12, 5), S(11, 17), S(9, 17), S(6, 5)};
-const i32 passers[] = {S(4, 14), S(35, 50), S(68, 124), S(220, 207)};
-const i32 pawn_passed_protected = S(11, 20);
-const i32 pawn_doubled_penalty = S(11, 37);
-const i32 pawn_phalanx = S(12, 11);
-const i32 pawn_passed_blocked_penalty[] = {S(9, 14), S(-7, 43), S(-9, 85), S(4, 97)};
+const i32 king_attacks[] = {S(10, -4), S(19, -5), S(27, -9), S(20, 5), 0};
+const i32 pawn_protection[] = {S(22, 14), S(2, 14), S(6, 17), S(8, 9), S(-5, 19), S(-30, 24)};
+const i32 pawn_threat_penalty[] = {S(-4, 1), S(21, 2), S(11, 6), S(10, 17), S(9, 16), S(5, 5)};
+const i32 passers[] = {S(3, 14), S(33, 50), S(63, 124), S(195, 253)};
+const i32 pawn_passed_protected = S(10, 18);
+const i32 pawn_doubled_penalty = S(10, 36);
+const i32 pawn_phalanx = S(12, 12);
+const i32 pawn_passed_blocked_penalty[] = {S(8, 13), S(-7, 40), S(-9, 82), S(-10, 158)};
 const i32 pawn_passed_king_distance[] = {S(1, -6), S(-4, 11)};
-const i32 bishop_pair = S(32, 72);
-const i32 king_shield[] = {S(36, -12), S(27, -7)};
+const i32 bishop_pair = S(32, 71);
+const i32 king_shield[] = {S(35, -11), S(27, -6)};
 const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
 
 [[nodiscard]] i32 eval(Position &pos) {
@@ -589,8 +589,10 @@ const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
     assert(phase >= 0);
 
     // Tapered eval with endgame scaling based on remaining pawn count of the stronger side
-    return (int16_t(score) * phase +
-            (score + 0x8000 >> 16) * (16 + count(pos.colour[score < 0] & pos.pieces[Pawn])) / 24 * (24 - phase)) /
+    const i32 stronger_side_pawns_missing = 8 - count(pos.colour[score < 0] & pos.pieces[Pawn]);
+    return (int16_t(score) * phase + (score + 0x8000 >> 16) *
+                                         (128 - stronger_side_pawns_missing * stronger_side_pawns_missing) / 128 *
+                                         (24 - phase)) /
            24;
 }
 


### PR DESCRIPTION
STC:
```
Elo   | 7.15 +- 5.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8896 W: 2503 L: 2320 D: 4073
Penta | [223, 1037, 1779, 1152, 257]
```
http://chess.grantnet.us/test/34676/

LTC:
```
Elo   | 4.80 +- 4.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13398 W: 3403 L: 3218 D: 6777
Penta | [212, 1551, 3014, 1684, 238]
```
http://chess.grantnet.us/test/34677/

Bench: 4926868
+8 bytes