### PR TITLE
Bishop coloured pawns evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,970 bytes
+4,018 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -422,50 +422,51 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {137, 443, 446, 837, 1693, 0, 0};
-const i32 material[] = {S(93, 137), S(325, 443), S(334, 446), S(440, 837), S(750, 1693), 0};
+const i32 max_material[] = {139, 432, 482, 837, 1703, 0, 0};
+const i32 material[] = {S(95, 139), S(326, 432), S(372, 482), S(442, 837), S(744, 1703), 0};
 const i32 pst_rank[] = {
     0,         S(-3, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
-    S(-3, -4), S(-1, -3), S(0, -1),  S(2, 2),   S(3, 3),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
-    S(-1, -1), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-8, 2),   // Bishop
+    S(-2, -4), S(-1, -2), S(0, -1),  S(2, 2),   S(3, 3),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
+    S(-1, -2), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-9, 2),   // Bishop
     S(0, -3),  S(-1, -3), S(-2, -2), S(-3, 0),  S(0, 2),  S(2, 2), S(1, 3),  S(3, 1),    // Rook
-    S(2, -11), S(3, -8),  S(1, -4),  S(0, 1),   S(-1, 5), S(0, 5), S(-3, 6), S(-1, 5),   // Queen
+    S(2, -11), S(3, -8),  S(1, -4),  S(0, 1),   S(-1, 5), S(0, 5), S(-3, 6), S(-1, 6),   // Queen
     S(-1, -5), S(1, -2),  0,         S(-2, 2),  S(0, 4),  S(5, 4), S(2, 3),  S(1, -3)    // King
 };
 const i32 pst_file[] = {
     S(-1, 1),  S(-2, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, -1),  // Pawn
-    S(-5, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  S(1, 0),  S(-1, -3),  // Knight
-    S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(1, 1),  S(-1, 1), S(2, 0),  S(0, -1),   // Bishop
+    S(-5, -2), S(-2, -1), S(0, 1),  S(2, 2),  S(2, 2),  S(2, 0),  S(1, 0),  S(-1, -2),  // Knight
+    S(-2, -1), 0,         S(1, 0),  S(0, 1),  S(1, 1),  S(-1, 1), S(2, -1), S(0, -1),   // Bishop
     S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(2, -1), S(1, 0),  S(1, 0),  S(-2, 0),   // Rook
     S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(1, -1),   // Queen
     S(-2, -5), S(2, -2),  S(-1, 1), S(-2, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
 };
 const i32 open_files[] = {
     // Semi open files
-    S(1, 5),
-    S(-5, 19),
+    S(2, 6),
+    S(-5, 17),
     S(18, 15),
-    S(3, 18),
-    S(-21, 9),
+    S(2, 18),
+    S(-22, 9),
     // Open files
-    S(-3, -11),
-    S(-11, 0),
-    S(46, 0),
-    S(-15, 37),
+    S(-2, -9),
+    S(-12, -3),
+    S(46, 1),
+    S(-15, 38),
     S(-59, 1),
 };
-const i32 mobilities[] = {S(9, 5), S(8, 7), S(3, 4), S(4, 2), S(-5, 0)};
-const i32 king_attacks[] = {S(10, -4), S(19, -5), S(27, -9), S(20, 5), 0};
-const i32 pawn_protection[] = {S(22, 14), S(2, 14), S(6, 17), S(8, 9), S(-5, 19), S(-30, 24)};
-const i32 pawn_threat_penalty[] = {S(-4, 1), S(21, 2), S(11, 6), S(10, 17), S(9, 16), S(5, 5)};
-const i32 passers[] = {S(3, 14), S(33, 50), S(63, 124), S(195, 253)};
-const i32 pawn_passed_protected = S(10, 18);
+const i32 mobilities[] = {S(9, 7), S(7, 5), S(3, 5), S(4, 2), S(-5, -1)};
+const i32 king_attacks[] = {S(11, -4), S(19, -5), S(27, -9), S(21, 4), 0};
+const i32 pawn_protection[] = {S(22, 15), S(2, 11), S(7, 24), S(8, 8), S(-5, 18), S(-30, 23)};
+const i32 pawn_threat_penalty[] = {S(-4, 0), S(22, 4), S(10, 4), S(11, 18), S(10, 16), S(5, 5)};
+const i32 passers[] = {S(2, 14), S(33, 51), S(62, 125), S(195, 256)};
+const i32 pawn_passed_protected = S(11, 18);
 const i32 pawn_doubled_penalty = S(10, 36);
 const i32 pawn_phalanx = S(12, 12);
-const i32 pawn_passed_blocked_penalty[] = {S(8, 13), S(-7, 40), S(-9, 82), S(-10, 158)};
+const i32 pawn_passed_blocked_penalty[] = {S(9, 11), S(-6, 38), S(-8, 80), S(-10, 159)};
 const i32 pawn_passed_king_distance[] = {S(1, -6), S(-4, 11)};
-const i32 bishop_pair = S(32, 71);
-const i32 king_shield[] = {S(35, -11), S(27, -6)};
+const i32 bishop_pair = S(35, 70);
+const i32 bishop_pawns_penalty[] = {S(6, 14), S(5, 1)};
+const i32 king_shield[] = {S(36, -11), S(28, -6)};
 const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
 
 [[nodiscard]] i32 eval(Position &pos) {
@@ -567,6 +568,15 @@ const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
                     // Open or semi-open files
                     if (!(0x101010101010101ull << file & pawns[0]))
                         score += open_files[!(0x101010101010101ull << file & pawns[1]) * 5 + p - 1];
+
+                    // Pawns on bishop coloured squares
+                    if (p == Bishop) {
+                        u64 mask = 0xAA55AA55AA55AA55ull;
+                        if (piece_bb & ~mask)
+                            mask = ~mask;
+                        for (i32 i = 0; i < 2; ++i)
+                            score -= bishop_pawns_penalty[i] * count(pawns[i] & mask);
+                    }
 
                     if (p == King && piece_bb & 0xC3D7) {
                         // C3D7 = Reasonable king squares


### PR DESCRIPTION
STC:
```
Elo   | 10.56 +- 6.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5562 W: 1586 L: 1417 D: 2559
Penta | [137, 620, 1123, 739, 162]
```
http://chess.grantnet.us/test/34785/

LTC:
```
Elo   | 7.64 +- 5.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7186 W: 1834 L: 1676 D: 3676
Penta | [114, 805, 1621, 915, 138]
```
http://chess.grantnet.us/test/34822/

Bench: 4043274
+48 bytes