### PR TITLE
Tweak datasets used for eval tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,970 bytes
+3,972 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -422,50 +422,50 @@ void generate_piece_moves(Move *const movelist,
 }
 
 const i32 phases[] = {0, 1, 1, 2, 4, 0};
-const i32 max_material[] = {137, 443, 446, 837, 1693, 0, 0};
-const i32 material[] = {S(93, 137), S(325, 443), S(334, 446), S(440, 837), S(750, 1693), 0};
+const i32 max_material[] = {149, 523, 525, 959, 1778, 0, 0};
+const i32 material[] = {S(88, 149), S(342, 523), S(356, 525), S(470, 959), S(1044, 1778), 0};
 const i32 pst_rank[] = {
-    0,         S(-3, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 2), 0,        0,          // Pawn
-    S(-3, -4), S(-1, -3), S(0, -1),  S(2, 2),   S(3, 3),  S(6, 1), S(4, 0),  S(-12, 1),  // Knight
-    S(-1, -1), S(2, -1),  S(2, 0),   S(2, 0),   S(2, 1),  S(3, 0), 0,        S(-8, 2),   // Bishop
-    S(0, -3),  S(-1, -3), S(-2, -2), S(-3, 0),  S(0, 2),  S(2, 2), S(1, 3),  S(3, 1),    // Rook
-    S(2, -11), S(3, -8),  S(1, -4),  S(0, 1),   S(-1, 5), S(0, 5), S(-3, 6), S(-1, 5),   // Queen
-    S(-1, -5), S(1, -2),  0,         S(-2, 2),  S(0, 4),  S(5, 4), S(2, 3),  S(1, -3)    // King
+    0,         S(-3, 0),  S(-3, -1), S(-1, -1), S(1, 0),  S(5, 3),  0,        0,          // Pawn
+    S(-1, -6), S(0, -3),  S(2, -1),  S(3, 3),   S(4, 4),  S(5, 2),  S(2, 0),  S(-16, 2),  // Knight
+    S(0, -2),  S(2, -1),  S(2, 0),   S(2, 0),   S(3, 0),  S(2, 0),  S(-1, 1), S(-10, 2),  // Bishop
+    S(0, -3),  S(-1, -3), S(-2, -2), S(-2, 1),  S(0, 2),  S(2, 2),  S(1, 3),  S(2, 1),    // Rook
+    S(3, -12), S(3, -8),  S(2, -4),  S(0, 2),   S(-1, 5), S(-1, 5), S(-4, 7), S(-2, 4),   // Queen
+    S(-3, -5), S(-2, -1), S(-3, 0),  S(-5, 3),  S(-2, 5), S(3, 4),  S(4, 2),  S(5, -6),   // King
 };
 const i32 pst_file[] = {
-    S(-1, 1),  S(-2, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, -1),  // Pawn
-    S(-5, -3), S(-2, -1), S(0, 1),  S(2, 3),  S(2, 2),  S(2, 0),  S(1, 0),  S(-1, -3),  // Knight
-    S(-2, 0),  0,         S(1, 0),  S(0, 1),  S(1, 1),  S(-1, 1), S(2, 0),  S(0, -1),   // Bishop
-    S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(2, -1), S(1, 0),  S(1, 0),  S(-2, 0),   // Rook
-    S(-2, -4), S(-1, -2), S(-1, 0), S(0, 1),  S(0, 2),  S(1, 2),  S(2, 1),  S(1, -1),   // Queen
-    S(-2, -5), S(2, -2),  S(-1, 1), S(-2, 2), S(-3, 2), S(-1, 1), S(2, -1), S(0, -5)    // King
+    S(-1, 1),  S(-2, 1),  S(-1, 0), S(0, -1), S(1, 0),  S(2, 0),  S(2, 0),  S(-1, 0),   // Pawn
+    S(-4, -3), S(-1, -1), S(0, 2),  S(2, 3),  S(2, 3),  S(2, 0),  S(1, -1), S(-1, -4),  // Knight
+    S(-2, -1), 0,         S(1, 0),  S(0, 1),  S(1, 1),  S(0, 1),  S(2, 0),  S(-1, -1),  // Bishop
+    S(-2, 0),  S(-1, 1),  S(0, 1),  S(1, 0),  S(1, -1), S(1, 0),  S(1, 0),  S(-1, -1),  // Rook
+    S(-2, -3), S(-1, -1), 0,        S(0, 1),  S(0, 2),  S(1, 2),  S(2, 0),  S(1, -1),   // Queen
+    S(-2, -5), S(3, -1),  S(-1, 1), S(-4, 3), S(-4, 3), S(-2, 2), S(2, 0),  S(0, -5),   // King
 };
 const i32 open_files[] = {
     // Semi open files
-    S(1, 5),
-    S(-5, 19),
-    S(18, 15),
+    S(2, 2),
+    S(-5, 20),
+    S(19, 16),
     S(3, 18),
-    S(-21, 9),
+    S(-19, 7),
     // Open files
-    S(-3, -11),
-    S(-11, 0),
-    S(46, 0),
-    S(-15, 37),
-    S(-59, 1),
+    S(-3, -14),
+    S(-9, -2),
+    S(48, -1),
+    S(-12, 32),
+    S(-56, -2),
 };
-const i32 mobilities[] = {S(9, 5), S(8, 7), S(3, 4), S(4, 2), S(-5, 0)};
-const i32 king_attacks[] = {S(10, -4), S(19, -5), S(27, -9), S(20, 5), 0};
-const i32 pawn_protection[] = {S(22, 14), S(2, 14), S(6, 17), S(8, 9), S(-5, 19), S(-30, 24)};
-const i32 pawn_threat_penalty[] = {S(-4, 1), S(21, 2), S(11, 6), S(10, 17), S(9, 16), S(5, 5)};
-const i32 passers[] = {S(3, 14), S(33, 50), S(63, 124), S(195, 253)};
-const i32 pawn_passed_protected = S(10, 18);
-const i32 pawn_doubled_penalty = S(10, 36);
-const i32 pawn_phalanx = S(12, 12);
-const i32 pawn_passed_blocked_penalty[] = {S(8, 13), S(-7, 40), S(-9, 82), S(-10, 158)};
-const i32 pawn_passed_king_distance[] = {S(1, -6), S(-4, 11)};
-const i32 bishop_pair = S(32, 71);
-const i32 king_shield[] = {S(35, -11), S(27, -6)};
+const i32 mobilities[] = {S(8, 5), S(7, 7), S(3, 5), S(3, 2), S(-4, -1)};
+const i32 king_attacks[] = {S(11, -4), S(18, -4), S(26, -9), S(18, 13), 0};
+const i32 pawn_protection[] = {S(22, 16), S(1, 19), S(5, 19), S(7, 10), S(-8, 23), S(-30, 26)};
+const i32 pawn_threat_penalty[] = {S(-3, 0), S(22, 0), S(12, 6), S(10, 20), S(9, 17), S(5, 8)};
+const i32 passers[] = {S(9, 13), S(46, 49), S(98, 117), S(277, 205)};
+const i32 pawn_passed_protected = S(12, 21);
+const i32 pawn_doubled_penalty = S(11, 38);
+const i32 pawn_phalanx = S(12, 16);
+const i32 pawn_passed_blocked_penalty[] = {S(6, 20), S(-7, 45), S(-7, 87), S(37, 95)};
+const i32 pawn_passed_king_distance[] = {S(-1, -6), S(-3, 12)};
+const i32 bishop_pair = S(29, 84);
+const i32 king_shield[] = {S(34, -10), S(25, -7)};
 const i32 pawn_attacked_penalty[] = {S(63, 14), S(156, 140)};
 
 [[nodiscard]] i32 eval(Position &pos) {


### PR DESCRIPTION
Currently uses a filtered version of Stoofvlees data, and 400k fens each of 12.33, 12.41 and zurichess (increased from 300k to make up for the reduction in fens after filtering)

STC:
Elo   | 5.94 +- 4.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12226 W: 3536 L: 3327 D: 5363
Penta | [348, 1425, 2402, 1546, 392]
http://chess.grantnet.us/test/35124/

LTC:
Elo   | 3.16 +- 2.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 30786 W: 8151 L: 7871 D: 14764
Penta | [652, 3709, 6457, 3857, 718]
http://chess.grantnet.us/test/35125/

+2 bytes
Bench 3661827