### PR TITLE
Nmp fail soft

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,979 bytes
+3,991 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,991 bytes
+3,990 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -706,21 +706,22 @@ i32 alphabeta(Position &pos,
             Position npos = pos;
             flip(npos);
             npos.ep = 0;
-            if (-alphabeta(npos,
-                           -beta,
-                           -alpha,
-                           depth - 4 - depth / 5 - min((static_eval - beta) / 196, 3),
-                           ply + 1,
-                           // minify enable filter delete
-                           nodes,
-                           // minify disable filter delete
-                           stop_time,
-                           stack,
-                           stop,
-                           hash_history,
-                           hh_table,
-                           false) >= beta)
-                return beta;
+            const i32 score = -alphabeta(npos,
+                                         -beta,
+                                         -alpha,
+                                         depth - 4 - depth / 5 - min((static_eval - beta) / 196, 3),
+                                         ply + 1,
+                                         // minify enable filter delete
+                                         nodes,
+                                         // minify disable filter delete
+                                         stop_time,
+                                         stack,
+                                         stop,
+                                         hash_history,
+                                         hh_table,
+                                         false);
+            if (score >= beta)
+                return score < mate_score - 256 ? score : beta;
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -689,6 +689,7 @@ i32 alphabeta(Position &pos,
         alpha = static_eval;
     }
 
+    i32 score;
     if (ply > 0 && !in_qsearch && !in_check && alpha == beta - 1) {
         // Reverse futility pruning
         if (depth < 8) {
@@ -706,20 +707,20 @@ i32 alphabeta(Position &pos,
             Position npos = pos;
             flip(npos);
             npos.ep = 0;
-            const i32 score = -alphabeta(npos,
-                                         -beta,
-                                         -alpha,
-                                         depth - 4 - depth / 5 - min((static_eval - beta) / 196, 3),
-                                         ply + 1,
-                                         // minify enable filter delete
-                                         nodes,
-                                         // minify disable filter delete
-                                         stop_time,
-                                         stack,
-                                         stop,
-                                         hash_history,
-                                         hh_table,
-                                         false);
+            score = -alphabeta(npos,
+                               -beta,
+                               -alpha,
+                               depth - 4 - depth / 5 - min((static_eval - beta) / 196, 3),
+                               ply + 1,
+                               // minify enable filter delete
+                               nodes,
+                               // minify disable filter delete
+                               stop_time,
+                               stack,
+                               stop,
+                               hash_history,
+                               hh_table,
+                               false);
             if (score >= beta)
                 return score < mate_score - 256 ? score : beta;
         }
@@ -783,7 +784,6 @@ i32 alphabeta(Position &pos,
         nodes++;
         // minify disable filter delete
 
-        i32 score;
         if (!num_moves_evaluated)
         full_window:
             score = -alphabeta(npos,


### PR DESCRIPTION
STC:
```
Elo   | 8.02 +- 5.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7622 W: 2121 L: 1945 D: 3556
Penta | [186, 848, 1592, 974, 211]
http://chess.grantnet.us/test/36285/
```

LTC:
```
Elo   | 3.66 +- 3.31 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20402 W: 5046 L: 4831 D: 10525
Penta | [321, 2384, 4600, 2551, 345]
http://chess.grantnet.us/test/36287/
```

+11 bytes

Bench 3725978