### PR TITLE
Add pawn-structure correction history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-3,937 bytes
+4,090 bytes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bash build-mini.sh
 
 ## 4ku-mini Size
 ```
-4,090 bytes
+4,096 bytes
 ```
 
 ---

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -686,7 +686,7 @@ i32 alphabeta(Position &pos,
 
     // If static_eval > tt_entry.score, tt_entry.flag cannot be Lower (ie must be Upper or Exact).
     // Otherwise, tt_entry.flag cannot be Upper (ie must be Lower or Exact).
-    if (tt_entry.key == (u64)tt_key && tt_entry.flag != static_eval > tt_entry.score)
+    if (tt_entry.key == tt_key && tt_entry.flag != static_eval > tt_entry.score)
         static_eval = tt_entry.score;
 
     if (in_qsearch && static_eval > alpha) {
@@ -879,9 +879,9 @@ i32 alphabeta(Position &pos,
         return in_check ? ply - mate_score : 0;
 
     // Update correction history table
-    i32 &e = ch_table[pos.flipped][hashp % 16384];
     if (!in_qsearch && !in_check && (best_move.from == best_move.to || None == piece_on(pos, best_move.to)) &&
         !(tt_flag == Lower && best_score <= static_eval) && !(tt_flag == Upper && best_score >= static_eval)) {
+        i32 &e = ch_table[pos.flipped][hashp % 16384];
         i32 nw = min(16, 1 + depth);
         e = min(max((e * (256 - nw) + nw * (best_score - static_eval) * 256) / 256, -8192), 8192);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -882,7 +882,7 @@ i32 alphabeta(Position &pos,
     if (!in_qsearch && !in_check && (best_move.from == best_move.to || None == piece_on(pos, best_move.to)) &&
         !(tt_flag == Lower && best_score <= static_eval) && !(tt_flag == Upper && best_score >= static_eval)) {
         i32 &e = ch_table[pos.flipped][hashp % 16384];
-        i32 nw = min(16, 1 + depth);
+        const i32 nw = min(16, 1 + depth);
         e = min(max((e * (256 - nw) + nw * (best_score - static_eval) * 256) / 256, -8192), 8192);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1205,6 +1205,7 @@ i32 main(
             break;
         else if (word == "ucinewgame") {
             memset(hh_table, 0, sizeof(hh_table));
+            memset(ch_table, 0, sizeof(ch_table));
             memset(transposition_table.data(), 0, sizeof(TTEntry) * transposition_table.size());
         } else if (word == "isready")
             cout << "readyok\n";


### PR DESCRIPTION
STC & LTC, courtesy of plutie:
```
Results of corrhist vs base (10+0.1, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 19.03 +/- 8.69, nElo: 28.25 +/- 12.88
LOS: 100.00 %, DrawRatio: 41.06 %, PairsRatio: 1.36
Games: 2796, Wins: 835, Losses: 682, Draws: 1279, Points: 1474.5 (52.74 %)
Ptnml(0-2): [63, 286, 574, 385, 90]
LLR: 2.95 (-2.94, 2.94) [0.00, 5.00]
```
```
Results of corrhist vs base (60+0.6, 1t, 64MB, UHO_Lichess_4852_v1.epd):
Elo: 30.29 +/- 10.34, nElo: 51.47 +/- 17.48
LOS: 100.00 %, DrawRatio: 49.01 %, PairsRatio: 1.78
Games: 1518, Wins: 427, Losses: 295, Draws: 796, Points: 825.0 (54.35 %)
Ptnml(0-2): [15, 124, 372, 210, 38]
LLR: 2.96 (-2.94, 2.94) [0.00, 5.00] 
```

## Possible areas for additional minification
1. `get_hash` now returns an `array<u64, 2>` instead of a `u64`. This means that callsites have to discard the pawn hash via `[0]` or use structured bindings if they want both hashes. We might be able to improve this. When writing this patch I experimented with the GCC `__int128` type plus bithacking but didn't get particularly amazing results.
2. The main update code:
```cpp
// Update correction history table
if (!in_qsearch && !in_check && (best_move.from == best_move.to || None == piece_on(pos, best_move.to)) &&
    !(tt_flag == Lower && best_score <= static_eval) && !(tt_flag == Upper && best_score >= static_eval)) {
    i32 &e = ch_table[pos.flipped][hashp % 16384];
    i32 nw = min(16, 1 + depth);
    e = min(max((e * (256 - nw) + nw * (best_score - static_eval) * 256) / 256, -8192), 8192);
}
```
This is a full-fat top-engine implementation. We may be able to squeeze out, say, 70% of the gains in exchange for a much simpler update rule, but I haven't experimented.

4090 bytes (+153)
Bench: 3957361